### PR TITLE
Add Standard ML JSON round-trip check (#2678)

### DIFF
--- a/.github/scripts/run_sml_roundtrip.py
+++ b/.github/scripts/run_sml_roundtrip.py
@@ -1,0 +1,158 @@
+r"""Standard ML JSON round-trip check (issue #2678).
+
+Literalize the shared ``roundtrip_input.json`` document to a Standard
+ML ``val myData : val_t = ...`` binding (with the generated tagged
+``val_t`` datatype), append a small ``toJson`` walker that maps each
+constructor to a JSON fragment and prints the result, compile with
+``mlton``, run the binary, and hand the emitted JSON to
+:func:`roundtrip_common.verify`.
+
+This lives here, driven by a step of the ``lint-sml`` job in
+``.github/workflows/lint.yml``, because that job is where the MLton
+toolchain is provisioned.  It shares the same input and comparison
+logic as the other per-language round-trip helpers.
+
+SML's standard basis has no JSON encoder.  MLton ships ``smlnj-lib``
+which includes a ``JSONPrinter`` structure, but that printer emits
+SML-flavored numbers (``~`` for negation) without translating to JSON's
+``-`` and calls :func:`Real.fmt` with default precision (12 significant
+digits), which loses the bits of ``1.7976931348623157``.  Rather than
+post-process around those mismatches, this script walks the generated
+``val_t`` constructors directly and emits JSON using a tiny
+``toJson`` function.  The walker covers exactly the six variants the
+shared input exercises (``SBool``, ``SInt``, ``SReal``, ``SStr``,
+``SList``, ``SMap``); a future expansion of ``roundtrip_input.json``
+adding a new scalar kind would fail compilation here until the match
+is extended.
+
+The shared input's ``biginteger`` field is excluded from the
+comparison: its 26-digit value exceeds SML's
+``BareIntegerWidthStrategies.BARE`` limit, so the literalizer raises
+``UnrepresentableIntegerError`` before emitting any code.
+``float_large_exponent`` is also excluded: ``format_float_repr``
+round-trips Python's ``repr(1.7976931348623157e308)`` verbatim as
+``1.7976931348623157e+308``, but the SML '97 numeric-literal grammar
+requires an uppercase ``E`` and ``~`` (not ``+``) before a positive
+exponent, so MLton rejects the literal.  Trimming the field
+keeps this round-trip focused on what the SML backend can actually
+emit today, separate from those orthogonal literalizer limitations.
+
+The literalized input contains the ``unicode é 中`` string, which
+embeds UTF-8 bytes in a source-level string literal.  MLton rejects
+those bytes under its default annotation set, so the compile step
+passes ``-default-ann 'allowExtendedTextConsts true'`` to opt in.  The
+``toJson`` emitter walks the string as bytes (``Char.ord c >= 32`` is
+passed through verbatim), so the UTF-8 sequence reconstitutes in the
+emitted JSON without ``\\uXXXX`` escaping.
+"""
+
+import shutil
+
+import roundtrip_common
+
+from literalizer.languages import Sml
+
+_VAR_NAME = "myData"
+_LABEL = "SML"
+_EXCLUDED_KEYS = ("biginteger", "float_large_exponent")
+
+_TO_JSON = r"""
+fun jsonString s =
+  let
+    fun escape c =
+      case c of
+        #"\"" => "\\\""
+      | #"\\" => "\\\\"
+      | #"\n" => "\\n"
+      | #"\r" => "\\r"
+      | #"\t" => "\\t"
+      | _ =>
+          if Char.ord c < 32
+          then "\\u00" ^ StringCvt.padLeft #"0" 2
+                 (Int.fmt StringCvt.HEX (Char.ord c))
+          else String.str c
+  in
+    "\"" ^ String.concat (List.map escape (String.explode s)) ^ "\""
+  end
+
+fun stripTilde s =
+  if String.isPrefix "~" s
+  then "-" ^ String.extract (s, 1, NONE)
+  else s
+
+fun jsonInt i = stripTilde (LargeInt.toString i)
+
+fun jsonReal r =
+  String.implode
+    (List.map (fn #"~" => #"-" | c => c)
+       (String.explode (Real.fmt (StringCvt.GEN (SOME 17)) r)))
+
+fun toJson v =
+  case v of
+    SBool true => "true"
+  | SBool false => "false"
+  | SInt i => jsonInt i
+  | SReal r => jsonReal r
+  | SStr s => jsonString s
+  | SList xs => "[" ^ String.concatWith "," (List.map toJson xs) ^ "]"
+  | SMap kvs =>
+      "{" ^ String.concatWith ","
+              (List.map (fn (k, v) => jsonString k ^ ":" ^ toJson v) kvs)
+        ^ "}"
+
+val () = print (toJson myData)
+"""
+
+
+def _build_program(json_text: str) -> str:
+    """Return a runnable SML program literalized from *json_text*."""
+    trimmed_json = roundtrip_common.trim_keys(
+        json_text=json_text,
+        excluded_keys=_EXCLUDED_KEYS,
+    )
+    result = roundtrip_common.literalize_new_variable(
+        language=Sml(),
+        json_text=trimmed_json,
+        var_name=_VAR_NAME,
+        pre_indent_level=0,
+    )
+    # ``Sml.literalize`` already inlines ``result.body_preamble`` (the
+    # ``datatype val_t`` declaration) at the top of ``result.code``, so
+    # we only join ``preamble`` (currently empty) with ``code`` here.
+    # Prepending ``body_preamble`` separately would duplicate the
+    # ``val_t`` type and break compilation.
+    preamble = "\n".join(result.preamble)
+    return f"{preamble}\n{result.code}\n{_TO_JSON}"
+
+
+def main() -> None:
+    """Round-trip the shared document through the SML backend."""
+    program = _build_program(json_text=roundtrip_common.read_input())
+    mlton = shutil.which(cmd="mlton") or "mlton"
+    roundtrip_common.execute(
+        label=_LABEL,
+        source_filename="main.sml",
+        program=program,
+        steps=[
+            roundtrip_common.Step(
+                args=[
+                    mlton,
+                    "-default-ann",
+                    "allowExtendedTextConsts true",
+                    "-output",
+                    "main",
+                    "main.sml",
+                ],
+                failure_label="mlton error",
+            ),
+            roundtrip_common.Step(
+                args=["./main"],
+                failure_label="run error",
+            ),
+        ],
+        excluded_keys=_EXCLUDED_KEYS,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1033,6 +1033,8 @@ jobs:
         run: |
           curl -fsSL https://github.com/MLton/mlton/releases/download/on-20241230-release/mlton-20241230-1.amd64-linux.ubuntu-24.04_static.tgz | tar xz -C /tmp
           echo "/tmp/mlton-20241230-1.amd64-linux.ubuntu-24.04_static/bin" >> "$GITHUB_PATH"
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8.1.0
 
       # Every fixture defines its own entry point at top level, so compile
       # and run each file directly. Each invocation gets a private tmpdir
@@ -1048,6 +1050,13 @@ jobs:
           "$tmpdir/out" || exit 1
           SCRIPT
           xargs -0 -P "$(nproc)" -n1 bash /tmp/run-sml.sh < /tmp/files-sml
+
+      # Driven from `lint-sml` because that is the job where MLton (pinned
+      # by the `Install MLton` step above) is installed; `uv run` (project
+      # mode, not `--no-project`) is required so `import literalizer`
+      # resolves. See `.github/scripts/run_sml_roundtrip.py`.
+      - name: SML roundtrip
+        run: uv run python .github/scripts/run_sml_roundtrip.py
 
   lint-elixir:
     runs-on: ubuntu-latest

--- a/newsfragments/2678.change
+++ b/newsfragments/2678.change
@@ -1,0 +1,1 @@
+Add a Standard ML JSON round-trip check to CI using the shared round-trip fixture.


### PR DESCRIPTION
## Summary

- Add `.github/scripts/run_sml_roundtrip.py` driving MLton over the shared `roundtrip_input.json`. The script walks the literalized `val_t` constructors with a small hand-rolled `toJson`, since SML's basis has no JSON encoder and smlnj-lib's `JSONPrinter` emits SML-flavored numbers (`~` for negation, default 12-digit precision) that don't satisfy JSON.
- Wire it into the `lint-sml` job (where MLton is already pinned) and add `setup-uv` so `import literalizer` resolves.
- Exclude `biginteger` (SML's BARE width strategy rejects the 26-digit value) and `float_large_exponent` (the SML '97 grammar rejects the `e+308` exponent the literalizer emits for that double) - both are pre-existing literalizer limitations, orthogonal to this check.

Closes #2678.

## Test plan

- [x] `uv run python .github/scripts/run_sml_roundtrip.py` locally (with MLton from Homebrew) prints `SML round-trip OK`
- [ ] `lint-sml` CI step passes on the new `SML roundtrip` step

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only addition following existing per-language roundtrip patterns; no runtime product or security-sensitive code paths.
> 
> **Overview**
> Adds **Standard ML** to the shared JSON round-trip CI checks for issue **#2678**.
> 
> A new **`.github/scripts/run_sml_roundtrip.py`** literalizes **`roundtrip_input.json`** via the **`Sml`** backend, appends a hand-rolled **`toJson`** over the generated **`val_t`** (SML has no standard JSON encoder; **`JSONPrinter`** would emit non-JSON number syntax and lose float precision), compiles with **MLton** (**`allowExtendedTextConsts`** for UTF-8 in literals), runs the binary, and verifies stdout with **`roundtrip_common`**. **`biginteger`** and **`float_large_exponent`** are trimmed from the fixture because the SML literalizer/grammar cannot represent those fields today.
> 
> The **`lint-sml`** workflow job gains **`setup-uv`** and an **`SML roundtrip`** step (**`uv run python .github/scripts/run_sml_roundtrip.py`**). A **newsfragment** records the user-facing change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0a0ea59d51386b57529a5baa9e8f5e5b881f7ebc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->