### PR TITLE
Use Jackson in the Kotlin JSON round-trip check (#2709)

### DIFF
--- a/.github/scripts/run_kotlin_roundtrip.py
+++ b/.github/scripts/run_kotlin_roundtrip.py
@@ -1,23 +1,29 @@
 """Kotlin JSON round-trip check (issue #1867).
 
 Literalize the shared ``roundtrip_input.json`` document to a Kotlin
-``val myData = ...`` declaration, wrap it in a tiny ``.kts`` script
-that walks the generated ``Any?`` value into a
-``kotlinx.serialization.json.JsonElement`` and prints
-``Json.encodeToString(...)`` to stdout, run it with ``kotlin``, and
-hand the emitted JSON to :func:`roundtrip_common.verify`.
+``val myData = ...`` declaration, wrap it in a tiny ``.kts`` script that
+prints ``ObjectMapper().writeValueAsString(myData)`` to stdout, run it
+with ``kotlin``, and hand the emitted JSON to
+:func:`roundtrip_common.verify`.
 
 This lives here, driven by a step of the ``lint-kotlin`` job in
 ``.github/workflows/lint.yml``, because that job is where the Kotlin
-toolchain and the ``kotlinx-serialization-json`` jars are already
-installed (same ``LITERALIZER_LINT_CLASSPATH`` the per-fixture compile
-host reads).  It shares the same input and comparison logic as the
-other per-language round-trip helpers.
+toolchain and the Jackson jars are already installed (same
+``LITERALIZER_LINT_CLASSPATH`` the per-fixture compile host reads).  It
+shares the same input and comparison logic as the other per-language
+round-trip helpers.
 
-The shared input's ``biginteger`` field is excluded from the comparison:
-its 26-digit value is emitted as ``java.math.BigInteger("...")`` which
-``kotlinx.serialization.json`` has no first-class ``JsonPrimitive``
-overload for, same shape as the Go, TypeScript and Zig exclusions.
+Jackson's ``ObjectMapper`` serializes the heterogeneous ``Any?`` tree
+the literalizer emits, including the primitive-typed arrays
+(``intArrayOf``, ``longArrayOf``, ...) the Kotlin backend uses for
+homogeneous numeric lists, without a hand-rolled walker (issue #2709).
+
+The shared input's ``biginteger`` field is excluded from the comparison
+for parity with the Go, TypeScript, Swift, and Zig exclusions: those
+backends collapse the 26-digit literal before serialization.  Kotlin
+emits it as ``java.math.BigInteger("...")`` and Jackson serializes it as
+an exact JSON number, but keeping the exclusion matches the other
+``LongArray``-shaped backends.
 """
 
 import os
@@ -31,30 +37,6 @@ from literalizer.languages import Kotlin
 _VAR_NAME = "myData"
 _LABEL = "Kotlin"
 _EXCLUDED_KEYS = ("biginteger",)
-
-# Recursive ``Any?`` -> ``JsonElement`` walker.  The Kotlin backend
-# emits primitive-typed arrays (``intArrayOf``, ...) for homogeneous
-# numeric lists, so each primitive-array shape needs its own branch
-# before the generic ``List<*>`` arm.  ``Map<*, *>`` covers both
-# ``mapOf<String, Any?>`` and the narrower homogeneous-value maps the
-# backend emits for inner objects.
-_TO_JSON_ELEMENT = r"""
-fun toJsonElement(v: Any?): JsonElement = when (v) {
-    null -> JsonNull
-    is Boolean -> JsonPrimitive(v)
-    is Number -> JsonPrimitive(v)
-    is String -> JsonPrimitive(v)
-    is IntArray -> JsonArray(v.map { JsonPrimitive(it) })
-    is LongArray -> JsonArray(v.map { JsonPrimitive(it) })
-    is DoubleArray -> JsonArray(v.map { JsonPrimitive(it) })
-    is BooleanArray -> JsonArray(v.map { JsonPrimitive(it) })
-    is List<*> -> JsonArray(v.map(::toJsonElement))
-    is Map<*, *> -> JsonObject(
-        v.entries.associate { (k, vv) -> k.toString() to toJsonElement(vv) }
-    )
-    else -> error("unhandled type: " + v::class)
-}
-"""
 
 
 def _build_program(json_text: str) -> str:
@@ -71,21 +53,11 @@ def _build_program(json_text: str) -> str:
     )
     preamble = "\n".join((*result.preamble, *result.body_preamble))
     return (
-        "import kotlinx.serialization.json.Json\n"
-        "import kotlinx.serialization.json.JsonArray\n"
-        "import kotlinx.serialization.json.JsonElement\n"
-        "import kotlinx.serialization.json.JsonNull\n"
-        "import kotlinx.serialization.json.JsonObject\n"
-        "import kotlinx.serialization.json.JsonPrimitive\n"
+        "import com.fasterxml.jackson.databind.ObjectMapper\n"
         f"{preamble}\n"
-        f"{_TO_JSON_ELEMENT}"
-        "\n"
         f"{result.code}\n"
         "\n"
-        "print(Json.encodeToString("
-        "JsonElement.serializer(), "
-        f"toJsonElement({_VAR_NAME})"
-        "))\n"
+        f"print(ObjectMapper().writeValueAsString({_VAR_NAME}))\n"
     )
 
 
@@ -94,7 +66,7 @@ def main() -> None:
     program = _build_program(json_text=roundtrip_common.read_input())
     kotlin = shutil.which(cmd="kotlin") or "kotlin"
     # ``LITERALIZER_LINT_CLASSPATH`` is set by the ``lint-kotlin`` job
-    # to ``/tmp/kotlinx-jars/*`` for the per-fixture compile host.  The
+    # to ``/tmp/jackson-jars/*`` for this round-trip step.  The
     # ``kotlin`` script wrapper does not forward the JVM ``dir/*``
     # wildcard intact, so expand it here to an explicit jar list.
     classpath = ":".join(

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1624,6 +1624,21 @@ jobs:
             name=$(basename "$f")
             curl -fsSL "https://repo1.maven.org/maven2/org/jetbrains/kotlinx/$f" -o "/tmp/kotlinx-jars/$name"
           done
+      # Jackson jars are needed by `run_kotlin_roundtrip.py`, which uses
+      # `ObjectMapper().writeValueAsString(...)` to dump the heterogeneous
+      # `Any?` literalized value (including primitive `IntArray`/`LongArray`
+      # etc) without a hand-rolled `JsonElement` walker. Pinned alongside
+      # the `Set up Jackson for Java` step above; bump together.
+      - name: Set up Jackson for Kotlin
+        run: |-
+          mkdir -p /tmp/jackson-jars
+          jackson_version=2.18.2
+          for f in jackson-databind/$jackson_version/jackson-databind-$jackson_version.jar \
+                   jackson-core/$jackson_version/jackson-core-$jackson_version.jar \
+                   jackson-annotations/$jackson_version/jackson-annotations-$jackson_version.jar; do
+            name=$(basename "$f")
+            curl -fsSL "https://repo1.maven.org/maven2/com/fasterxml/jackson/core/$f" -o "/tmp/jackson-jars/$name"
+          done
       # Invoke K2JVMCompiler from a single `.main.kts` JVM instead of
       # spawning one `kotlinc -script` per fixture. The JVM + compiler
       # classes load once and each fixture is compiled against the warm
@@ -1640,14 +1655,15 @@ jobs:
           enable-cache: true
           cache-dependency-glob: '**/pyproject.toml'
       # Basic JSON -> Kotlin -> JSON round-trip (issue 1867). Runs here
-      # because this is the job with the Kotlin toolchain and the
-      # kotlinx-serialization-json jars already on disk; `uv run`
-      # (project mode, not `--no-project`) is required so
-      # `import literalizer` resolves. See
-      # `.github/scripts/run_kotlin_roundtrip.py`.
+      # because this is the job with the Kotlin toolchain on hand; the
+      # script (issue 2709) prints
+      # `ObjectMapper().writeValueAsString(myData)` so the classpath
+      # points at the Jackson jars set up above. `uv run` (project mode,
+      # not `--no-project`) is required so `import literalizer`
+      # resolves. See `.github/scripts/run_kotlin_roundtrip.py`.
       - name: Kotlin roundtrip
         env:
-          LITERALIZER_LINT_CLASSPATH: /tmp/kotlinx-jars/*
+          LITERALIZER_LINT_CLASSPATH: /tmp/jackson-jars/*
         run: uv run python .github/scripts/run_kotlin_roundtrip.py
 
   lint-swift:

--- a/newsfragments/2709.change
+++ b/newsfragments/2709.change
@@ -1,0 +1,1 @@
+The Kotlin JSON round-trip CI check now serializes via Jackson's ``ObjectMapper`` instead of a hand-rolled ``toJsonElement`` walker over heterogeneous ``Any?`` plus primitive-array types.


### PR DESCRIPTION
## Summary

- Replaces the hand-rolled `toJsonElement` walker in `.github/scripts/run_kotlin_roundtrip.py` with `ObjectMapper().writeValueAsString(myData)`, which natively handles heterogeneous `Any?`, `List`/`Map`, and primitive arrays (`IntArray`, `LongArray`, ...).
- Adds a `Set up Jackson for Kotlin` step in the `lint-kotlin` job pinned to `jackson_version=2.18.2` (paired with the existing Java setup) and points the round-trip step's `LITERALIZER_LINT_CLASSPATH` at the Jackson jars; the kotlinx-serialization-json setup is kept for the `Check Kotlin syntax` step that compiles `KOTLINX_JSON_ELEMENT` fixtures.

Closes #2709.

## Test plan

- [ ] `lint-kotlin` job green (both `Check Kotlin syntax` against kotlinx jars and `Kotlin roundtrip` against Jackson jars).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change to how the Kotlin round-trip script serializes test output; production literalizer code is untouched.
> 
> **Overview**
> The Kotlin JSON round-trip CI helper no longer builds a custom `toJsonElement` tree and encodes with kotlinx.serialization. It now prints **`ObjectMapper().writeValueAsString(myData)`**, relying on Jackson to serialize heterogeneous `Any?` values and primitive arrays (`intArrayOf`, etc.).
> 
> In **`lint-kotlin`**, a new **Set up Jackson for Kotlin** step downloads Jackson **2.18.2** (aligned with the existing Java setup). The **Kotlin roundtrip** step’s `LITERALIZER_LINT_CLASSPATH` points at those jars; **Check Kotlin syntax** still uses kotlinx-serialization jars for `KOTLINX_JSON_ELEMENT` fixtures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2ee506c110214c840d557cd5280e5478fce43328. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->