### PR TITLE
Add Objective-C JSON round-trip check (#2668)

### DIFF
--- a/.github/scripts/run_objective_c_roundtrip.py
+++ b/.github/scripts/run_objective_c_roundtrip.py
@@ -1,0 +1,98 @@
+"""Objective-C JSON round-trip check (issue #2668).
+
+Literalize the shared ``roundtrip_input.json`` document to an
+Objective-C ``id myData = @{...};`` declaration, wrap it in a tiny
+``main`` that serializes ``myData`` back to JSON via
+``NSJSONSerialization`` from ``Foundation`` and writes the bytes to
+stdout, compile and run it with ``clang``, and hand the emitted JSON
+to :func:`roundtrip_common.verify`.
+
+This lives here, driven by a step of the ``lint-objectivec`` job in
+``.github/workflows/lint.yml``, because that job is where the
+Objective-C toolchain (Apple ``clang`` plus the ``Foundation``
+framework) is already available.  It shares the same input and
+comparison logic as the other per-language round-trip helpers.
+
+The shared input's ``biginteger`` field is excluded from the
+comparison: its 26-digit value overflows the widest integer literal
+the Objective-C backend emits (``unsigned long long``), so the
+program would not compile if the field were kept.  Same shape as the
+C++, Go, TypeScript, Zig, Swift, Rust and D exclusions.
+"""
+
+import shutil
+
+import roundtrip_common
+
+from literalizer.languages import ObjectiveC
+
+_VAR_NAME = "myData"
+_LABEL = "Objective-C"
+_EXCLUDED_KEYS = ("biginteger",)
+
+
+def _build_program(json_text: str) -> str:
+    """Return a runnable Objective-C program literalized from
+    *json_text*.
+    """
+    trimmed_json = roundtrip_common.trim_keys(
+        json_text=json_text,
+        excluded_keys=_EXCLUDED_KEYS,
+    )
+    result = roundtrip_common.literalize_new_variable(
+        language=ObjectiveC(),
+        json_text=trimmed_json,
+        var_name=_VAR_NAME,
+        pre_indent_level=1,
+    )
+    preamble = "\n".join((*result.preamble, *result.body_preamble))
+    return (
+        f"{preamble}\n"
+        "int main(void) {\n"
+        "@autoreleasepool {\n"
+        f"{result.code}\n"
+        "    NSData *jsonData = [NSJSONSerialization\n"
+        f"        dataWithJSONObject:{_VAR_NAME}\n"
+        "        options:0\n"
+        "        error:nil];\n"
+        "    NSFileHandle *out =\n"
+        "        [NSFileHandle fileHandleWithStandardOutput];\n"
+        "    [out writeData:jsonData];\n"
+        "}\n"
+        "    return 0;\n"
+        "}\n"
+    )
+
+
+def main() -> None:
+    """Round-trip the shared document through the Objective-C backend."""
+    program = _build_program(json_text=roundtrip_common.read_input())
+    clang = shutil.which(cmd="clang") or "clang"
+    roundtrip_common.execute(
+        label=_LABEL,
+        source_filename="main.m",
+        program=program,
+        steps=[
+            roundtrip_common.Step(
+                args=[
+                    clang,
+                    "-framework",
+                    "Foundation",
+                    "-Werror",
+                    "main.m",
+                    "-o",
+                    "main",
+                ],
+                failure_label="clang error",
+            ),
+            roundtrip_common.Step(
+                args=["./main"],
+                failure_label="run error",
+            ),
+        ],
+        excluded_keys=_EXCLUDED_KEYS,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2723,6 +2723,21 @@ jobs:
           "$tmpdir/out" || exit 1
           SCRIPT
           xargs -0 -P "$(sysctl -n hw.ncpu)" -n1 bash /tmp/run-objc.sh < /tmp/files-to-lint
+      # `uv` is needed by the `Objective-C roundtrip` step below; it runs
+      # the helper in project mode so `import literalizer` resolves.
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8.1.0
+        with:
+          enable-cache: true
+          cache-dependency-glob: '**/pyproject.toml'
+      # Basic JSON -> Objective-C -> JSON round-trip (issue 2668). Runs
+      # here because this is the job with the Objective-C toolchain
+      # (Apple `clang` plus the `Foundation` framework); `uv run`
+      # (project mode, not `--no-project`) is required so
+      # `import literalizer` resolves. See
+      # `.github/scripts/run_objective_c_roundtrip.py`.
+      - name: Objective-C roundtrip
+        run: uv run python .github/scripts/run_objective_c_roundtrip.py
 
   lint-objectivec-tidy:
     # ``macos-15`` pins the runner image to match ``lint-objectivec`` so

--- a/newsfragments/2668.change
+++ b/newsfragments/2668.change
@@ -1,0 +1,1 @@
+Add an Objective-C JSON round-trip check to CI using the shared round-trip fixture.


### PR DESCRIPTION
## Summary
- New `.github/scripts/run_objective_c_roundtrip.py` literalizes the shared `roundtrip_input.json` through `ObjectiveC()`, wraps it in a tiny `main` that serializes via `NSJSONSerialization` from `Foundation`, compiles with `clang`, and hands stdout to `roundtrip_common.verify`.
- Wired as an `Objective-C roundtrip` step in the `lint-objectivec` job (`uv` installed first so project-mode `import literalizer` resolves). Excludes `biginteger` like the other backends whose widest integer literal can't hold 26 digits.
- Added `newsfragments/2668.change`.

## Test plan
- [x] `uv run python .github/scripts/run_objective_c_roundtrip.py` locally
- [ ] `lint-objectivec` CI job

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only adds a CI script and workflow steps; no changes to the literalizer library or runtime behavior for users.
> 
> **Overview**
> Adds **Objective-C** to the shared JSON round-trip CI checks for issue **#2668**.
> 
> A new helper **`.github/scripts/run_objective_c_roundtrip.py`** literalizes `roundtrip_input.json` with the `ObjectiveC()` backend, builds a small `main.m` that serializes via **`NSJSONSerialization`** and writes JSON to stdout, then compiles with **`clang -framework Foundation`** and verifies output through **`roundtrip_common`**. **`biginteger`** is dropped from the comparison (same as several other backends that cannot represent the 26-digit literal).
> 
> The **`lint-objectivec`** job on **`macos-15`** gains **`Install uv`** and an **`Objective-C roundtrip`** step (`uv run python ...`). A **`newsfragments/2668.change`** entry documents the addition.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1b7d4245d3b4a581d099ce5b30f44ae19da5927b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->