### PR TITLE
Add Haxe JSON round-trip check (#2656)

### DIFF
--- a/.github/scripts/run_haxe_roundtrip.py
+++ b/.github/scripts/run_haxe_roundtrip.py
@@ -1,0 +1,76 @@
+"""Haxe JSON round-trip check (issue #1867).
+
+Literalize the shared ``roundtrip_input.json`` document to a Haxe
+``final myData = ([...] : Map<String, Dynamic>)`` binding, wrap it in a
+tiny ``class Main`` whose ``main()`` prints ``haxe.Json.stringify(myData)``
+from the Haxe standard library, run it under ``haxe --interp``, and
+hand the emitted JSON to :func:`roundtrip_common.verify`.
+
+This lives here, driven by a step of the ``lint-haxe`` job in
+``.github/workflows/lint.yml``, because that job is where the Haxe
+toolchain is already installed.  It shares the same input and
+comparison logic as the other per-language round-trip helpers.
+
+The shared input's ``biginteger`` field is excluded from the
+comparison: the literalized program represents the 26-digit value as
+an ``Int`` literal, which the eval/``--interp`` target promotes to
+``Float`` (losing precision well before the round-trip back to JSON).
+Trimming the field before literalization keeps the generated program
+free of values the eval target would silently coerce.
+"""
+
+import shutil
+
+import roundtrip_common
+
+from literalizer.languages import Haxe
+
+_VAR_NAME = "myData"
+_LABEL = "Haxe"
+_EXCLUDED_KEYS = ("biginteger",)
+
+
+def _build_program(json_text: str) -> str:
+    """Return a runnable Haxe program literalized from *json_text*."""
+    trimmed = roundtrip_common.trim_keys(
+        json_text=json_text,
+        excluded_keys=_EXCLUDED_KEYS,
+    )
+    result = roundtrip_common.literalize_new_variable(
+        language=Haxe(),
+        json_text=trimmed,
+        var_name=_VAR_NAME,
+        pre_indent_level=0,
+    )
+    preamble = "\n".join((*result.preamble, *result.body_preamble))
+    return (
+        f"{preamble}\n"
+        "class Main {\n"
+        "  static function main() {\n"
+        f"    {result.code}\n"
+        f"    Sys.print(haxe.Json.stringify({_VAR_NAME}));\n"
+        "  }\n"
+        "}\n"
+    )
+
+
+def main() -> None:
+    """Round-trip the shared document through the Haxe backend."""
+    program = _build_program(json_text=roundtrip_common.read_input())
+    haxe = shutil.which(cmd="haxe") or "haxe"
+    roundtrip_common.execute(
+        label=_LABEL,
+        source_filename="Main.hx",
+        program=program,
+        steps=(
+            roundtrip_common.Step(
+                args=(haxe, "--main", "Main", "--interp"),
+                failure_label="haxe --interp error",
+            ),
+        ),
+        excluded_keys=_EXCLUDED_KEYS,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1873,6 +1873,20 @@ jobs:
           done < /tmp/files-to-lint
           printf '  }\n}\n' >> "$driver"
           haxe -p "$workspace" --main Driver --interp
+      # `uv` is needed by the `Haxe roundtrip` step below; it runs the
+      # helper in project mode so `import literalizer` resolves.
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8.1.0
+        with:
+          enable-cache: true
+          cache-dependency-glob: '**/pyproject.toml'
+      # Basic JSON -> Haxe -> JSON round-trip (issue  # 1867). Runs here
+      # because this is the job with the Haxe toolchain; `uv run`
+      # (project mode, not `--no-project`) is required so `import
+      # literalizer` resolves. See
+      # `.github/scripts/run_haxe_roundtrip.py`.
+      - name: Haxe roundtrip
+        run: uv run python .github/scripts/run_haxe_roundtrip.py
 
   lint-dart:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- New `.github/scripts/run_haxe_roundtrip.py` literalizes the shared `roundtrip_input.json` to Haxe, runs it under `haxe --interp`, and verifies that `haxe.Json.stringify` reproduces the input, modeled directly on the Dart helper.
- Excludes only the `biginteger` field since the Haxe eval target coerces the 26-digit literal to `Float`; uses the Haxe stdlib JSON encoder so no extra dependencies are needed.
- Wired into the existing `lint-haxe` job in `.github/workflows/lint.yml` (added `setup-uv` and the `Haxe roundtrip` step alongside the existing fixture compile step).

Closes #2656.

## Test plan
- [x] `uv run --extra dev python .github/scripts/run_haxe_roundtrip.py` -> `Haxe round-trip OK`
- [ ] CI `lint-haxe` job green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only integration test glue following existing round-trip scripts; no production runtime or security-sensitive code paths.
> 
> **Overview**
> Adds **Haxe** to the shared JSON round-trip CI checks: a new `.github/scripts/run_haxe_roundtrip.py` literalizes `roundtrip_input.json` via the Haxe backend, runs `haxe --main Main --interp`, and compares stdout to the input through `roundtrip_common` (same pattern as Dart/JavaScript helpers).
> 
> The **`biginteger`** top-level field is stripped before literalization and excluded from verification because `haxe --interp` promotes large `Int` literals to `Float`, which cannot round-trip the 26-digit value.
> 
> The **`lint-haxe`** workflow job now installs **`uv`** and runs `uv run python .github/scripts/run_haxe_roundtrip.py` after the existing fixture driver compile, reusing the job’s pinned Haxe toolchain and stdlib `haxe.Json.stringify`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4508613b849850860bd646d272fa69f87eb5f649. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->