### PR TITLE
Add Elixir JSON round-trip check (#2649)

### DIFF
--- a/.github/scripts/run_elixir_roundtrip.py
+++ b/.github/scripts/run_elixir_roundtrip.py
@@ -1,0 +1,61 @@
+"""Elixir JSON round-trip check (issue #1867).
+
+Literalize the shared ``roundtrip_input.json`` document to an Elixir
+``my_data = %{...}`` binding, wrap it in a tiny ``.exs`` script that
+prints ``JSON.encode!(my_data)`` on standard output, run it under
+``elixir``, and hand the emitted JSON to :func:`roundtrip_common.verify`.
+
+This lives here, driven by the ``Elixir roundtrip`` step of the
+``lint-elixir`` job in ``.github/workflows/lint.yml``, because that job
+is where the Elixir toolchain is installed.  It shares the same input
+and comparison logic as the other per-language round-trip helpers.
+
+The serializer is Elixir 1.18's built-in ``JSON`` module rather than a
+hand-rolled encoder (matching the preference expressed in the issue
+notes).  ``JSON.encode!/1`` natively handles arbitrary-precision
+integers, IEEE 754 doubles, booleans, ``nil``, lists and
+string-keyed maps, which is everything the shared input carries.
+"""
+
+import shutil
+
+import roundtrip_common
+
+from literalizer.languages import Elixir
+
+_VAR_NAME = "my_data"
+_LABEL = "Elixir"
+
+
+def _build_program(json_text: str) -> str:
+    """Return a runnable Elixir script literalized from *json_text*."""
+    result = roundtrip_common.literalize_new_variable(
+        language=Elixir(),
+        json_text=json_text,
+        var_name=_VAR_NAME,
+        pre_indent_level=0,
+    )
+    preamble = "\n".join((*result.preamble, *result.body_preamble))
+    return f"{preamble}\n{result.code}\nIO.write(JSON.encode!({_VAR_NAME}))\n"
+
+
+def main() -> None:
+    """Round-trip the shared document through the Elixir backend."""
+    program = _build_program(json_text=roundtrip_common.read_input())
+    elixir = shutil.which(cmd="elixir") or "elixir"
+    roundtrip_common.execute(
+        label=_LABEL,
+        source_filename="main.exs",
+        program=program,
+        steps=[
+            roundtrip_common.Step(
+                args=[elixir, "main.exs"],
+                failure_label="elixir runtime error",
+            ),
+        ],
+        excluded_keys=(),
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1136,6 +1136,22 @@ jobs:
           python3 -m tests.integration.list_fixtures .ex "$ELIXIR_FIXTURE_TAG" > /tmp/files-elixir && test -s /tmp/files-elixir
           elixir .github/scripts/lint-elixir.exs < /tmp/files-elixir
 
+      # `uv` is needed by the `Elixir roundtrip` step below; it runs the
+      # helper in project mode so `import literalizer` resolves.
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8.1.0
+        with:
+          enable-cache: true
+          cache-dependency-glob: '**/pyproject.toml'
+      # Basic JSON -> Elixir -> JSON round-trip (issue 1867). Runs here
+      # because this is the job with the Elixir toolchain (`elixir` on
+      # PATH, Elixir 1.18's built-in `JSON` module available); `uv run`
+      # (project mode, not `--no-project`) is required so
+      # `import literalizer` resolves. See
+      # `.github/scripts/run_elixir_roundtrip.py`.
+      - name: Elixir roundtrip
+        run: uv run python .github/scripts/run_elixir_roundtrip.py
+
   lint-erlang:
     runs-on: ubuntu-latest
     # Every Erlang fixture on disk carries the tag from

--- a/newsfragments/2649.change
+++ b/newsfragments/2649.change
@@ -1,0 +1,1 @@
+Add an Elixir JSON round-trip check to CI using the shared round-trip fixture.


### PR DESCRIPTION
## Summary
- Adds `.github/scripts/run_elixir_roundtrip.py`, mirroring the Java/Ruby/Erlang pattern: literalize the shared `roundtrip_input.json` to `my_data = %{...}`, print `JSON.encode!(my_data)` from a `.exs` script, and verify via `roundtrip_common`. Uses Elixir 1.18's built-in `JSON` module rather than a hand-rolled encoder.
- Wires the new step into the `lint-elixir` job in `.github/workflows/lint.yml` (with an `Install uv` step so `import literalizer` resolves in project mode), plus a towncrier fragment.

## Test plan
- [x] `uv run python .github/scripts/run_elixir_roundtrip.py` → `Elixir round-trip OK` locally
- [ ] `lint-elixir` job passes in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only CI and script additions; no runtime product code or auth/data paths change.
> 
> **Overview**
> Adds **CI coverage** so Elixir follows the same **JSON → literalized Elixir → JSON** path as other languages, using the shared `roundtrip_input.json` fixture and `roundtrip_common.verify`.
> 
> A new helper **`.github/scripts/run_elixir_roundtrip.py`** literalizes the input to `my_data`, runs a `.exs` script that prints **`JSON.encode!(my_data)`** (Elixir 1.18 built-in `JSON`), and compares output to the original. The **`lint-elixir`** job gains **`Install uv`** and an **`Elixir roundtrip`** step (`uv run python …`). A **towncrier** fragment documents the change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 43fa2e817d5aebbf07726ea45514579eeb0f5b03. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->