### PR TITLE
Add Erlang(json_type=OTP_JSON) for built-in json:encode/1 rendering

### DIFF
--- a/.github/scripts/run_erlang_roundtrip.py
+++ b/.github/scripts/run_erlang_roundtrip.py
@@ -1,10 +1,13 @@
 """Erlang JSON round-trip check (issue #1867).
 
 Literalize the shared ``roundtrip_input.json`` document to an Erlang
-``MyData = #{...},`` map binding, wrap it in an ``escript`` whose
-``main/1`` normalizes Erlang charlist strings/keys to UTF-8 binaries
-and prints ``json:encode(...)`` on standard output, run it under
-``escript``, and hand the emitted JSON to :func:`roundtrip_common.verify`.
+``MyData = #{...},`` map binding using the ``OTP_JSON`` json_type so
+every string, ISO date / datetime / time, and base64-encoded bytes
+value renders as a UTF-8 binary literal (``<<"..."/utf8>>``) and
+``null`` is the bare atom ``null``.  Wrap the binding in an
+``escript`` whose ``main/1`` prints ``json:encode(MyData)`` on
+standard output, run it under ``escript``, and hand the emitted JSON
+to :func:`roundtrip_common.verify`.
 
 This lives here, driven by the ``Erlang roundtrip`` step of the
 ``lint-erlang`` job in ``.github/workflows/lint.yml``, because that job
@@ -13,13 +16,9 @@ input and comparison logic as the other per-language round-trip helpers.
 
 The serializer is OTP 27's built-in ``json`` module rather than a
 hand-rolled encoder (matching the preference expressed in the issue
-notes).  The default ``json`` encoder rejects Erlang charlists as map
-keys and emits charlist string values as arrays of integers, so the
-program first deep-normalizes the literalized data: charlist map keys
-and printable charlist values become UTF-8 binaries, while non-printable
-lists (e.g. ``[1, 2, 3]``) stay lists.  The non-empty guard on
-``io_lib:printable_unicode_list/1`` keeps ``[]`` (an ``empty_array``)
-from being mistakenly converted to ``<<>>``.
+notes).  Under ``OTP_JSON`` the rendered value is already in the shape
+``json:encode/1`` accepts (binary keys, binary string values, ``null``
+atom), so no normalization walker is needed.
 """
 
 import shutil
@@ -31,30 +30,17 @@ from literalizer.languages import Erlang
 _VAR_NAME = "myData"
 _LABEL = "Erlang"
 
-_NORMALIZE_AND_ENCODE = """\
+_ENCODE = """\
     ok = io:setopts(standard_io, [{encoding, unicode}]),
-    Json = json:encode(normalize(MyData)),
+    Json = json:encode(MyData),
     ok = io:put_chars(Json).
-
-normalize(M) when is_map(M) ->
-    maps:from_list(
-      [{to_binary_key(K), normalize(V)} || {K, V} <- maps:to_list(M)]);
-normalize(L) when is_list(L) ->
-    case L =/= [] andalso io_lib:printable_unicode_list(L) of
-        true -> unicode:characters_to_binary(L);
-        false -> [normalize(X) || X <- L]
-    end;
-normalize(X) -> X.
-
-to_binary_key(K) when is_list(K) -> unicode:characters_to_binary(K);
-to_binary_key(K) -> K.
 """
 
 
 def _build_program(json_text: str) -> str:
     """Return a runnable Erlang escript literalized from *json_text*."""
     result = roundtrip_common.literalize_new_variable(
-        language=Erlang(),
+        language=Erlang(json_type=Erlang.json_types.OTP_JSON),
         json_text=json_text,
         var_name=_VAR_NAME,
         pre_indent_level=0,
@@ -66,7 +52,7 @@ def _build_program(json_text: str) -> str:
         "\n"
         "main(_) ->\n"
         f"    {indented_decl}\n"
-        f"{_NORMALIZE_AND_ENCODE}"
+        f"{_ENCODE}"
     )
 
 

--- a/docs/source/languages.rst
+++ b/docs/source/languages.rst
@@ -455,6 +455,33 @@ so no walker is needed before ``Json.Encode.encode 0`` and
 heterogeneous collections are accepted.  Dict keys must be strings so
 they remain valid JSON object keys.
 
+Erlang exposes the same option through
+``Erlang.json_types.OTP_JSON``:
+
+.. code-block:: python
+
+   """Render Erlang data for Erlang's built-in json module."""
+
+   from literalizer import InputFormat, NewVariable, literalize
+   from literalizer.languages import Erlang
+
+   result = literalize(
+       source='{"id": 1, "tags": ["red", 2]}',
+       input_format=InputFormat.JSON,
+       language=Erlang(json_type=Erlang.json_types.OTP_JSON),
+       variable_form=NewVariable(name="payload"),
+   )
+
+This emits string values, dict keys, ISO 8601 dates / datetimes /
+times, and base64-encoded bytes as UTF-8 binary literals
+(``<<"..."/utf8>>``) rather than Erlang's default ``"..."`` string
+form (a list of code points), since Erlang's ``json:encode/1``
+(available since ``OTP_27``) rejects the list form as a map key and
+emits list-form string values as arrays of integers.  Null renders
+as the bare atom ``null`` (rather than ``undefined``), and sets
+render as JSON arrays.  Dict keys must be strings so they remain
+valid JSON object keys.
+
 D's polarity is reversed from the others: its default already renders
 every value through ``std.json.JSONValue``, so the ``json_type``
 constructor argument selects the inverse mode.  ``D.json_types.STD_JSON_VALUE``

--- a/newsfragments/2716.change
+++ b/newsfragments/2716.change
@@ -1,0 +1,1 @@
+Add ``Erlang(json_type=Erlang.json_types.OTP_JSON)`` to render strings, ISO dates, datetimes, times, and base64-encoded bytes as UTF-8 binary literals (``<<"..."/utf8>>``), null as the bare atom ``null``, and sets as JSON arrays, so the rendered value feeds straight into Erlang's built-in ``json:encode/1`` (available since ``OTP_27``) without a normalization pass.

--- a/src/literalizer/languages/erlang.py
+++ b/src/literalizer/languages/erlang.py
@@ -76,11 +76,13 @@ from literalizer._language import (
     no_leading_preamble,
     no_type_hint_preamble,
     no_validate_call_arg,
-    no_validate_spec_for_data,
     prepend_body_preamble,
 )
 from literalizer._types import Value
-from literalizer.exceptions import WrapCombinedInFileNotSupportedError
+from literalizer.exceptions import (
+    UnrepresentableInputError,
+    WrapCombinedInFileNotSupportedError,
+)
 
 
 @beartype
@@ -88,6 +90,88 @@ def _format_bytes(value: bytes) -> str:
     """Format bytes as an Erlang binary literal."""
     parts = ", ".join(f"{b}" for b in value)
     return f"<<{parts}>>"
+
+
+@beartype
+def _wrap_utf8_binary(quoted: str) -> str:
+    """Wrap an already-double-quoted literal in ``<<".."/utf8>>``.
+
+    Erlang's standard ``json:encode/1`` rejects the default ``"..."``
+    string form (a list of code points): map keys would parse as lists
+    rather than strings, and string values would emit as arrays of
+    integers.  Under the
+    ``OTP_JSON`` json_type every textual scalar (strings, ISO date /
+    datetime / time strings, base64-encoded bytes) is wrapped in a
+    UTF-8 binary literal so the standard ``json`` module accepts the
+    rendered value directly.
+    """
+    return f"<<{quoted}/utf8>>"
+
+
+@beartype
+def _format_string_otp_json(value: str) -> str:
+    """Format a string as an Erlang UTF-8 binary literal."""
+    return _wrap_utf8_binary(quoted=format_string_backslash(value))
+
+
+@beartype
+def _format_bytes_otp_json(value: bytes) -> str:
+    """Format bytes as a base64-encoded UTF-8 binary literal.
+
+    The default :func:`_format_bytes` emits a raw byte binary
+    (``<<1, 2, 3>>``), which Erlang's ``json:encode/1`` rejects unless
+    the bytes happen to form valid UTF-8.  Base64 is a JSON-safe ASCII
+    encoding that round-trips arbitrary bytes through any JSON
+    transport.
+    """
+    return _wrap_utf8_binary(quoted=format_bytes_base64(value=value))
+
+
+@beartype
+def _format_date_otp_json(value: datetime.date) -> str:
+    """Format a date as an ISO 8601 UTF-8 binary literal."""
+    return _wrap_utf8_binary(quoted=format_date_iso(value=value))
+
+
+@beartype
+def _format_datetime_otp_json(value: datetime.datetime) -> str:
+    """Format a datetime as an ISO 8601 UTF-8 binary literal."""
+    return _wrap_utf8_binary(quoted=format_datetime_iso(value=value))
+
+
+@beartype
+def _format_time_otp_json(value: datetime.time) -> str:
+    """Format a time as an ISO 8601 UTF-8 binary literal."""
+    return _wrap_utf8_binary(quoted=format_time_iso(value=value))
+
+
+@beartype
+def _validate_erlang_otp_json_data(*, data: Value) -> None:
+    """Reject inputs ``OTP_JSON`` rendering cannot represent.
+
+    Erlang's ``json:encode/1`` map keys must be JSON-encodable
+    scalars; under :attr:`Erlang.json_type` the literalizer emits
+    every textual scalar as a UTF-8 binary, so non-string keys
+    (atoms, integers, tuples) would round-trip as something other
+    than the user's original key.  The default Erlang renderer still
+    accepts those keys.
+    """
+    match data:
+        case dict():
+            for key, value in data.items():
+                if not isinstance(key, str):
+                    msg = (
+                        "Erlang(json_type=OTP_JSON) cannot represent "
+                        f"dict key {key!r}: json:encode/1 requires "
+                        "string keys."
+                    )
+                    raise UnrepresentableInputError(msg)
+                _validate_erlang_otp_json_data(data=value)
+        case list() | set():
+            for item in data:
+                _validate_erlang_otp_json_data(data=item)
+        case _:
+            return
 
 
 @beartype
@@ -483,6 +567,21 @@ class Erlang(metaclass=LanguageCls):
 
     version_formats = VersionFormats
 
+    class JsonTypes(enum.Enum):
+        """JSON value type options for Erlang."""
+
+        OTP_JSON = enum.auto()
+        """Erlang's built-in ``json`` module (``OTP_27`` and later).
+
+        Renders strings, ISO dates / datetimes / times, and bytes
+        (base64-encoded) as UTF-8 binary literals so
+        ``json:encode/1`` accepts the value directly.  Null is emitted
+        as the bare atom ``null``; sets render as JSON arrays.  Dict
+        keys must be strings (validated upfront).
+        """
+
+    json_types = JsonTypes
+
     module_name_case: ClassVar[IdentifierCase] = IdentifierCase.SNAKE
     modifier_combinations: ClassVar[tuple[ModifierCombination, ...]] = ()
     identifier_cases: ClassVar[tuple[IdentifierCase, ...]] = (
@@ -491,8 +590,6 @@ class Erlang(metaclass=LanguageCls):
     supported_ref_cases: ClassVar[frozenset[IdentifierCase]] = (
         NON_KEBAB_REF_CASES
     )
-
-    validate_spec_for_data = no_validate_spec_for_data
 
     @cached_property
     def validate_call_arg(self) -> Callable[[Value], None]:
@@ -616,9 +713,9 @@ class Erlang(metaclass=LanguageCls):
         HeterogeneousStrategies.ERROR
     )
     language_version: VersionFormats = VersionFormats.OTP_25
+    json_type: JsonTypes | None = None
     indent: str = "    "
 
-    null_literal: ClassVar[str] = "undefined"
     true_literal: ClassVar[str] = "true"
     false_literal: ClassVar[str] = "false"
     indent_closing_delimiter: ClassVar[bool] = False
@@ -633,8 +730,38 @@ class Erlang(metaclass=LanguageCls):
     special_float_preamble: ClassVar[tuple[str, ...]] = ()
 
     @cached_property
+    def _json_type_active(self) -> bool:
+        """``True`` when ``OTP_JSON`` rendering is selected."""
+        return self.json_type is not None
+
+    @cached_property
+    def null_literal(self) -> str:
+        """Null literal: ``null`` under ``OTP_JSON``, ``undefined``
+        otherwise.
+
+        Erlang's ``json:encode/1`` rejects the bare atom ``undefined``
+        (it is not in the documented set of accepted scalars) but
+        encodes ``null`` as JSON ``null``.
+        """
+        if self._json_type_active:
+            return "null"
+        return "undefined"
+
+    def validate_spec_for_data(self, data: Value) -> None:
+        """Validate Erlang-specific data/format combinations.
+
+        Under :attr:`json_type` every dict key must be a string so the
+        rendered map keys (UTF-8 binaries) match what Erlang's
+        ``json:encode/1`` expects.
+        """
+        if self._json_type_active:
+            _validate_erlang_otp_json_data(data=data)
+
+    @cached_property
     def format_string(self) -> Callable[[str], str]:
         """Format a string value as a quoted literal."""
+        if self._json_type_active:
+            return _format_string_otp_json
         return format_string_backslash
 
     @cached_property
@@ -763,6 +890,15 @@ class Erlang(metaclass=LanguageCls):
     @cached_property
     def set_format_config(self) -> SetFormatConfig:
         """Configuration for the chosen set format."""
+        if self._json_type_active:
+            # Erlang's ``json:encode/1`` has no set type: render sets
+            # as JSON arrays (Erlang lists) the same as sequences.
+            return dataclasses.replace(
+                self.set_format.value,
+                set_open=fixed_open(open_str="["),
+                close="]",
+                empty_set="[]",
+            )
         return self.set_format.value
 
     @cached_property
@@ -794,21 +930,29 @@ class Erlang(metaclass=LanguageCls):
     @cached_property
     def format_bytes(self) -> Callable[[bytes], str]:
         """Callable that formats a bytes value as a string literal."""
+        if self._json_type_active:
+            return _format_bytes_otp_json
         return self.bytes_format
 
     @cached_property
     def format_date(self) -> Callable[[datetime.date], str]:
         """Callable that formats a date as a string literal."""
+        if self._json_type_active:
+            return _format_date_otp_json
         return self.date_format
 
     @cached_property
     def format_datetime(self) -> Callable[[datetime.datetime], str]:
         """Callable that formats a datetime as a string literal."""
+        if self._json_type_active:
+            return _format_datetime_otp_json
         return self.datetime_format
 
     @cached_property
     def format_time(self) -> Callable[[datetime.time], str]:
         """Callable that formats a time as a string literal."""
+        if self._json_type_active:
+            return _format_time_otp_json
         return format_time_iso
 
     @cached_property

--- a/tests/errors/test_erlang_json_type_errors.py
+++ b/tests/errors/test_erlang_json_type_errors.py
@@ -1,0 +1,21 @@
+"""Erlang ``json_type`` rejection paths."""
+
+import pytest
+
+from literalizer import InputFormat, NewVariable, literalize
+from literalizer.exceptions import UnrepresentableInputError
+from literalizer.languages import Erlang
+
+
+def test_erlang_json_type_rejects_non_string_dict_keys() -> None:
+    """Erlang's ``json:encode/1`` requires string keys."""
+    with pytest.raises(
+        expected_exception=UnrepresentableInputError,
+        match="cannot represent dict key",
+    ):
+        literalize(
+            source="{1: one}",
+            input_format=InputFormat.YAML,
+            language=Erlang(json_type=Erlang.json_types.OTP_JSON),
+            variable_form=NewVariable(name="myData"),
+        )

--- a/tests/integration/cases/binary/Erlang_json_type_otp_json_binary@otp_25.erl
+++ b/tests/integration/cases/binary/Erlang_json_type_otp_json_binary@otp_25.erl
@@ -1,0 +1,7 @@
+-module(fixture_binary_erlang_json_type_otp_json_binary).
+-export([x/0]).
+x() ->
+    My_data = [
+        <<"SGVsbG8="/utf8>>
+    ],
+    My_data.

--- a/tests/integration/cases/bool_list/Erlang_json_type_otp_json_bool_list@otp_25.erl
+++ b/tests/integration/cases/bool_list/Erlang_json_type_otp_json_bool_list@otp_25.erl
@@ -1,0 +1,9 @@
+-module(fixture_bool_list_erlang_json_type_otp_json_bool_list).
+-export([x/0]).
+x() ->
+    My_data = [
+        true,
+        false,
+        true
+    ],
+    My_data.

--- a/tests/integration/cases/call_scalar_args/Erlang_json_type_otp_json_call@otp_25.erl
+++ b/tests/integration/cases/call_scalar_args/Erlang_json_type_otp_json_call@otp_25.erl
@@ -1,0 +1,7 @@
+-module(fixture_call_scalar_args_erlang_json_type_otp_json_call).
+-export([x/0]).
+process(_) -> ok.
+x() ->
+    process(<<"hello"/utf8>>),
+    process(42),
+    process(true).

--- a/tests/integration/cases/date_set/Erlang_json_type_otp_json_date_set@otp_25.erl
+++ b/tests/integration/cases/date_set/Erlang_json_type_otp_json_date_set@otp_25.erl
@@ -1,0 +1,8 @@
+-module(fixture_date_set_erlang_json_type_otp_json_date_set).
+-export([x/0]).
+x() ->
+    My_data = [
+        <<"2024-01-15"/utf8>>,
+        <<"2024-06-01"/utf8>>
+    ],
+    My_data.

--- a/tests/integration/cases/dates/Erlang_json_type_otp_json_dates@otp_25.erl
+++ b/tests/integration/cases/dates/Erlang_json_type_otp_json_dates@otp_25.erl
@@ -1,0 +1,8 @@
+-module(fixture_dates_erlang_json_type_otp_json_dates).
+-export([x/0]).
+x() ->
+    My_data = #{
+        <<"date"/utf8>> => <<"2024-01-15"/utf8>>,
+        <<"datetime"/utf8>> => <<"2024-01-15T12:30:00+00:00"/utf8>>
+    },
+    My_data.

--- a/tests/integration/cases/dict_with_list_value/Erlang_json_type_otp_json@otp_25.erl
+++ b/tests/integration/cases/dict_with_list_value/Erlang_json_type_otp_json@otp_25.erl
@@ -1,0 +1,8 @@
+-module(fixture_dict_with_list_value_erlang_json_type_otp_json).
+-export([x/0]).
+x() ->
+    My_data = #{
+        <<"name"/utf8>> => <<"Alice"/utf8>>,
+        <<"scores"/utf8>> => [10, 20, 30]
+    },
+    My_data.

--- a/tests/integration/cases/dict_with_nulls/Erlang_json_type_otp_json_nulls@otp_25.erl
+++ b/tests/integration/cases/dict_with_nulls/Erlang_json_type_otp_json_nulls@otp_25.erl
@@ -1,0 +1,9 @@
+-module(fixture_dict_with_nulls_erlang_json_type_otp_json_nulls).
+-export([x/0]).
+x() ->
+    My_data = #{
+        <<"name"/utf8>> => <<"Alice"/utf8>>,
+        <<"score"/utf8>> => null,
+        <<"age"/utf8>> => 30
+    },
+    My_data.

--- a/tests/integration/cases/nested_mixed_inner/Erlang_json_type_otp_json_nested_mixed@otp_25.erl
+++ b/tests/integration/cases/nested_mixed_inner/Erlang_json_type_otp_json_nested_mixed@otp_25.erl
@@ -1,0 +1,8 @@
+-module(fixture_nested_mixed_inner_erlang_json_type_otp_json_nested_mixed).
+-export([x/0]).
+x() ->
+    My_data = [
+        [1, <<"a"/utf8>>],
+        [2, <<"b"/utf8>>]
+    ],
+    My_data.

--- a/tests/integration/cases/ordered_map/Erlang_json_type_otp_json_ordered_map@otp_25.erl
+++ b/tests/integration/cases/ordered_map/Erlang_json_type_otp_json_ordered_map@otp_25.erl
@@ -1,0 +1,9 @@
+-module(fixture_ordered_map_erlang_json_type_otp_json_ordered_map).
+-export([x/0]).
+x() ->
+    My_data = [
+        {<<"name"/utf8>>, <<"Alice"/utf8>>},
+        {<<"age"/utf8>>, 30},
+        {<<"active"/utf8>>, true}
+    ],
+    My_data.

--- a/tests/integration/cases/scalar_datetime_naive/Erlang_json_type_otp_json_datetime_naive@otp_25.erl
+++ b/tests/integration/cases/scalar_datetime_naive/Erlang_json_type_otp_json_datetime_naive@otp_25.erl
@@ -1,0 +1,5 @@
+-module(fixture_scalar_datetime_naive_erlang_json_type_otp_json_datetime_naive).
+-export([x/0]).
+x() ->
+    My_data = <<"2024-01-15T12:30:00"/utf8>>,
+    My_data.

--- a/tests/integration/cases/scalar_float/Erlang_json_type_otp_json_float@otp_25.erl
+++ b/tests/integration/cases/scalar_float/Erlang_json_type_otp_json_float@otp_25.erl
@@ -1,0 +1,5 @@
+-module(fixture_scalar_float_erlang_json_type_otp_json_float).
+-export([x/0]).
+x() ->
+    My_data = 3.14,
+    My_data.

--- a/tests/integration/cases/scalar_int_large/Erlang_json_type_otp_json_long@otp_25.erl
+++ b/tests/integration/cases/scalar_int_large/Erlang_json_type_otp_json_long@otp_25.erl
@@ -1,0 +1,5 @@
+-module(fixture_scalar_int_large_erlang_json_type_otp_json_long).
+-export([x/0]).
+x() ->
+    My_data = 2147483648,
+    My_data.

--- a/tests/integration/cases/scalar_int_very_large/Erlang_json_type_otp_json_bigint@otp_25.erl
+++ b/tests/integration/cases/scalar_int_very_large/Erlang_json_type_otp_json_bigint@otp_25.erl
@@ -1,0 +1,5 @@
+-module(fixture_scalar_int_very_large_erlang_json_type_otp_json_bigint).
+-export([x/0]).
+x() ->
+    My_data = 9223372036854775808,
+    My_data.

--- a/tests/integration/cases/scalar_time/Erlang_json_type_otp_json_time@otp_25.erl
+++ b/tests/integration/cases/scalar_time/Erlang_json_type_otp_json_time@otp_25.erl
@@ -1,0 +1,7 @@
+-module(fixture_scalar_time_erlang_json_type_otp_json_time).
+-export([x/0]).
+x() ->
+    My_data = #{
+        <<"starts_at"/utf8>> => <<"09:30:00"/utf8>>
+    },
+    My_data.

--- a/tests/integration/variant_cases.py
+++ b/tests/integration/variant_cases.py
@@ -26,6 +26,7 @@ from literalizer.languages import (
     Dart,
     Dhall,
     Elm,
+    Erlang,
     Fortran,
     FSharp,
     Gleam,
@@ -607,6 +608,15 @@ def build_json_type_variants() -> Iterable[Variant]:
                 json_type=Elm.json_types.JSON_ENCODE_VALUE,
             ),
             lang_cls=Elm,
+            collection_layout=literalizer.CollectionLayout.COMPACT,
+        ),
+        Variant(
+            name="Erlang_json_type_otp_json",
+            spec=make_spec(
+                lang_cls=Erlang,
+                json_type=Erlang.json_types.OTP_JSON,
+            ),
+            lang_cls=Erlang,
             collection_layout=literalizer.CollectionLayout.COMPACT,
         ),
     ]


### PR DESCRIPTION
## Summary

Resolves #2716 (Erlang half). Adds ``Erlang(json_type=Erlang.json_types.OTP_JSON)`` so strings, ISO dates / datetimes / times, and base64-encoded bytes render as UTF-8 binary literals (``<<"..."/utf8>>``), null becomes the bare atom ``null``, and sets render as JSON arrays — making the rendered value feed straight into Erlang's built-in ``json:encode/1`` (available since OTP 27). The Erlang roundtrip helper drops its charlist-to-binary ``normalize`` walker; non-string dict keys are rejected upfront via ``validate_spec_for_data``. Racket's ``->jsexpr`` half of #2716 will follow as a separate PR.

## Test plan

- [ ] CI ``lint-erlang`` job: 13 new golden fixtures compile under ``erlc -Werror`` and run under ``M:x()``.
- [ ] CI ``lint-erlang`` Erlang roundtrip step round-trips ``roundtrip_input.json`` through the new json_type without normalization.
- [ ] Full pytest suite (golden, variant, errors, coverage gate at 100%).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive literalizer option, docs, tests, and a CI roundtrip simplification; no auth, security, or production runtime paths beyond Erlang output shape.
> 
> **Overview**
> Adds **`Erlang(json_type=Erlang.json_types.OTP_JSON)`** so literalized data matches what OTP 27’s **`json:encode/1`** expects: textual scalars (strings, ISO dates/datetimes/times, base64 bytes) as **`<<"…"/utf8>>`**, **`null`** instead of **`undefined`**, and **sets** as lists. Non-string dict keys are rejected up front via **`validate_spec_for_data`**.
> 
> The **Erlang CI roundtrip** now literalizes with **`OTP_JSON`** and calls **`json:encode(MyData)`** directly, dropping the old charlist-to-binary **`normalize`** walker. Docs, a newsfragment, integration goldens, a variant matrix entry, and an error test cover the new mode.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 32198a0fc9cda27e54d409fbd9c88e839307a524. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->