### PR TITLE
Add VB.NET JSON round-trip CI check (#2682)

### DIFF
--- a/.github/scripts/run_vb_roundtrip.py
+++ b/.github/scripts/run_vb_roundtrip.py
@@ -1,0 +1,107 @@
+"""Visual Basic (.NET) JSON round-trip check (issue #2682).
+
+Literalize the shared ``roundtrip_input.json`` document to a VB.NET
+``Dim myData = ...`` binding, wrap it in a tiny ``Module Program``
+whose ``Sub Main`` prints
+``System.Text.Json.JsonSerializer.Serialize(myData)``, ``dotnet run``
+it, and hand the emitted JSON to :func:`roundtrip_common.verify`.
+
+``System.Text.Json`` is part of the .NET base class library, so no
+NuGet packages are needed; serializing through ``Object`` dispatches
+on the runtime type and walks ``IDictionary`` / array values
+polymorphically.
+
+The shared input's ``biginteger`` field is excluded from the comparison:
+its 26-digit value exceeds every VB.NET integer literal type the
+literalizer emits, so the program would not compile if the field were
+kept.  Same shape as the C# exclusion.
+
+This lives here, driven by the ``VisualBasic roundtrip`` step of the
+``lint-dotnet`` job in ``.github/workflows/lint.yml``, because that job
+is where the .NET toolchain is installed; it is deliberately not a
+pytest test under ``tests/``.
+"""
+
+import shutil
+
+import roundtrip_common
+
+from literalizer.languages import VisualBasic
+
+_VAR_NAME = "myData"
+_LABEL = "VisualBasic"
+_EXCLUDED_KEYS = ("biginteger",)
+
+# ``LangVersion 16.9`` matches ``VisualBasic.language_version`` in
+# ``src/literalizer/languages/vb.py`` and the
+# ``LanguageVersion.VisualBasic16_9`` pin in
+# ``.github/scripts/lint-vb/Program.cs``; keep them in sync.
+_VBPROJ = (
+    '<Project Sdk="Microsoft.NET.Sdk">\n'
+    "  <PropertyGroup>\n"
+    "    <OutputType>Exe</OutputType>\n"
+    "    <TargetFramework>net8.0</TargetFramework>\n"
+    "    <RollForward>LatestMajor</RollForward>\n"
+    "    <OptionStrict>Off</OptionStrict>\n"
+    "    <OptionInfer>On</OptionInfer>\n"
+    "    <LangVersion>16.9</LangVersion>\n"
+    "  </PropertyGroup>\n"
+    "</Project>\n"
+)
+
+
+def _build_program(json_text: str) -> str:
+    """Return a runnable VB.NET program literalized from *json_text*."""
+    trimmed_json = roundtrip_common.trim_keys(
+        json_text=json_text,
+        excluded_keys=_EXCLUDED_KEYS,
+    )
+    result = roundtrip_common.literalize_new_variable(
+        language=VisualBasic(),
+        json_text=trimmed_json,
+        var_name=_VAR_NAME,
+        pre_indent_level=2,
+    )
+    preamble = "\n".join(result.preamble)
+    body_preamble = "\n".join(result.body_preamble)
+    return (
+        f"{preamble}\n"
+        "Imports System\n"
+        "Imports System.Text.Json\n"
+        f"{body_preamble}\n"
+        "Module Program\n"
+        "    Sub Main()\n"
+        f"{result.code}\n"
+        f"        Console.Write(JsonSerializer.Serialize({_VAR_NAME}))\n"
+        "    End Sub\n"
+        "End Module\n"
+    )
+
+
+def main() -> None:
+    """Round-trip the shared document through the VB.NET backend."""
+    program = _build_program(json_text=roundtrip_common.read_input())
+    dotnet = shutil.which(cmd="dotnet") or "dotnet"
+    roundtrip_common.execute(
+        label=_LABEL,
+        source_filename="Program.vb",
+        program=program,
+        steps=[
+            roundtrip_common.Step(
+                args=[
+                    dotnet,
+                    "run",
+                    "--project",
+                    "fixture.vbproj",
+                    "--nologo",
+                ],
+                failure_label="dotnet run error",
+            ),
+        ],
+        excluded_keys=_EXCLUDED_KEYS,
+        extra_files={"fixture.vbproj": _VBPROJ},
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1041,6 +1041,14 @@ jobs:
           find tests/integration/cases -name '*.vb' -print0 > /tmp/files-vb && test -s /tmp/files-vb
           dotnet /tmp/lint-vb/lint-vb.dll < /tmp/files-vb
 
+      # Basic JSON -> VB.NET -> JSON round-trip (issue 2682). Runs here
+      # because this is the job with the .NET toolchain; `uv run`
+      # (project mode, not `--no-project`) is required so
+      # `import literalizer` resolves. See
+      # `.github/scripts/run_vb_roundtrip.py`.
+      - name: VisualBasic roundtrip
+        run: uv run python .github/scripts/run_vb_roundtrip.py
+
       # Generate an FSX driver that `#load`s every fixture, then
       # evaluate it in a single `dotnet fsi --exec` invocation so the
       # .NET runtime and FSI compiler start up once instead of per

--- a/newsfragments/2682.change
+++ b/newsfragments/2682.change
@@ -1,0 +1,1 @@
+Add a Visual Basic JSON round-trip check to CI using the shared round-trip fixture.


### PR DESCRIPTION
## Summary
- Adds `.github/scripts/run_vb_roundtrip.py`, which literalizes the shared `roundtrip_input.json` into a `Module Program` / `Sub Main` and serializes via `System.Text.Json.JsonSerializer.Serialize` (no NuGet packages needed). The `biginteger` field is excluded for the same reason as C#: it exceeds VB.NET's widest integer literal type.
- Wires a `VisualBasic roundtrip` step into the `lint-dotnet` job in `.github/workflows/lint.yml`, where the .NET toolchain is already provisioned.
- Pins `LangVersion 16.9` in the inline `fixture.vbproj` and cross-references `vb.py` / `lint-vb/Program.cs` so the three pin sites stay in sync.

## Test plan
- [x] `uv run python .github/scripts/run_vb_roundtrip.py` → `VisualBasic round-trip OK`
- [x] pre-commit hooks (ruff, actionlint, yamlfix, zizmor, pylint, ...) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only addition following the established roundtrip_common pattern; no production literalizer API or runtime behavior changes beyond new coverage.
> 
> **Overview**
> Adds **Visual Basic .NET** to the shared JSON round-trip CI pattern used for C# and other languages.
> 
> A new `.github/scripts/run_vb_roundtrip.py` literalizes `roundtrip_input.json` with the `VisualBasic` backend, wraps the result in a small `Module Program` / `Sub Main`, runs `dotnet run` against an inline `fixture.vbproj` (`net8.0`, `LangVersion 16.9`, `OptionStrict` off / `OptionInfer` on), and compares output via `roundtrip_common.verify` using `System.Text.Json.JsonSerializer.Serialize`. The **`biginteger`** field is dropped from the fixture for the same reason as C# (value too large for emitted VB integer literals).
> 
> The **`lint-dotnet`** job in `.github/workflows/lint.yml` gains a **`VisualBasic roundtrip`** step (`uv run python .github/scripts/run_vb_roundtrip.py`) immediately after VB fixture linting. A **newsfragment** records the user-facing change for issue #2682.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb5d530bf3e77e3bf07b207d5a5a6673ad34a7a2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->