### PR TITLE
Bump ty 0.0.39 → 0.0.40 and drop unsound Callable attrs from LanguageCls

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,7 +92,7 @@ optional-dependencies.dev = [
     "sphinxcontrib-towncrier==0.5.0a0",
     "strict-kwargs==2026.5.20",
     "towncrier==25.8.0",
-    "ty==0.0.39",
+    "ty==0.0.40",
     "types-pygments==2.20.0.20260518",
     "vulture==2.16",
     "yamlfix==1.19.1",

--- a/src/literalizer/_language.py
+++ b/src/literalizer/_language.py
@@ -824,11 +824,6 @@ class LanguageCls(type):
     supports_record_struct_name_prefix: bool
     supports_record_shape_names: bool
     dict_supports_heterogeneous_values: bool
-    format_call_arg: FormatCallArg
-    format_constructor_target: Callable[[str], str]
-    validate_call_arg: Callable[[Value], None]
-    format_call_statement: Callable[[str], str]
-    call_data_dependent_preamble: Callable[[Value], tuple[str, ...]]
 
     def __call__(cls, *args: object, **kwargs: object) -> "Language":
         """Construct a language instance, typed as :class:`Language`."""


### PR DESCRIPTION
## Summary

- Bumps ty from 0.0.39 to 0.0.40 (dependabot).
- Removes five class-level `Callable[...]` attribute declarations from the `LanguageCls` metaclass that ty 0.0.40 (correctly) flags as unsound: each one is implemented in subclasses as a `@cached_property` or `staticmethod` descriptor, so the value visible on the class object is the bare descriptor, not the declared `Callable`. No code in `src/` or `tests/` accesses these via the class, and the instance-level `Language` Protocol `@property` declarations remain — so callers are still typed correctly.

## Test plan

- [x] `uv run --extra dev ty check` passes
- [x] `uv run --extra dev pyright` passes
- [x] `uv run --extra dev pyrefly check` passes
- [x] `uv run --extra dev mypy src/` passes
- [x] `uv run --extra dev pytest` (5374 passed, 30517 subtests passed)

Upstream issues filed for the underlying ty 0.0.40 diagnostics: astral-sh/ty#3568, astral-sh/ty#3569.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency pin and type-stub cleanup only; no runtime behavior changes and call sites remain typed through the `Language` protocol.
> 
> **Overview**
> Bumps the dev dependency **ty** from `0.0.39` to `0.0.40` in `pyproject.toml`.
> 
> In `LanguageCls`, removes five class-level `Callable[...]` annotations (`format_call_arg`, `format_constructor_target`, `validate_call_arg`, `format_call_statement`, `call_data_dependent_preamble`) that ty 0.0.40 flags as unsound because subclasses expose them as `@cached_property` / `staticmethod` descriptors on the class object, not as plain callables. Instance typing for callers is unchanged via the `Language` protocol `@property` declarations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2719bcc79f524eae0a9ff1210c10cf5138f4deb3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->