### PR TITLE
Expose JsonTypes/BoolFormats on every Language subclass (#2755)

### DIFF
--- a/.github/scripts/run_scala_roundtrip.py
+++ b/.github/scripts/run_scala_roundtrip.py
@@ -30,7 +30,7 @@ _CIRCE_DEP = "io.circe::circe-core:0.14.10"
 def _build_program(json_text: str) -> str:
     """Return a runnable Scala program literalized from *json_text*."""
     result = roundtrip_common.literalize_new_variable(
-        language=Scala(json_type=Scala.JsonTypes.CIRCE),  # pyright: ignore[reportUnknownMemberType, reportUnknownArgumentType, reportAttributeAccessIssue]
+        language=Scala(json_type=Scala.json_types.CIRCE),
         json_text=json_text,
         var_name=_VAR_NAME,
         pre_indent_level=1,

--- a/.github/scripts/run_scala_roundtrip.py
+++ b/.github/scripts/run_scala_roundtrip.py
@@ -30,7 +30,7 @@ _CIRCE_DEP = "io.circe::circe-core:0.14.10"
 def _build_program(json_text: str) -> str:
     """Return a runnable Scala program literalized from *json_text*."""
     result = roundtrip_common.literalize_new_variable(
-        language=Scala(json_type=Scala.JsonTypes.CIRCE),
+        language=Scala(json_type=Scala.JsonTypes.CIRCE),  # pyright: ignore[reportUnknownMemberType, reportUnknownArgumentType, reportAttributeAccessIssue]
         json_text=json_text,
         var_name=_VAR_NAME,
         pre_indent_level=1,

--- a/newsfragments/2755.change
+++ b/newsfragments/2755.change
@@ -1,0 +1,1 @@
+Expose the nested ``JsonTypes`` and ``BoolFormats`` enum classes (plus their snake_case ``json_types`` / ``bool_formats`` aliases) on every ``Language`` subclass, using an empty enum for languages that do not support these options. Consumers can now enumerate these options uniformly across languages without reflection helpers.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,6 +91,10 @@ optional-dependencies.dev = [
     # well as in the ``release`` extra (used by the release workflow).
     "sphinxcontrib-towncrier==0.5.0a0",
     "strict-kwargs==2026.5.20",
+    # pyproject-fmt 2.21.2 has no upper bound on toml-fmt-common and
+    # is broken by toml-fmt-common 1.3.3+ (duplicate --table-format flag).
+    # Keep in sync with the pyproject-fmt pin above.
+    "toml-fmt-common==1.3.2",
     "towncrier==25.8.0",
     "ty==0.0.40",
     "types-pygments==2.20.0.20260518",

--- a/src/literalizer/_language.py
+++ b/src/literalizer/_language.py
@@ -790,6 +790,8 @@ class LanguageCls(type):
     CallStyles: type[enum.Enum]
     Modifiers: type[enum.Enum]
     HeterogeneousStrategies: type[enum.Enum]
+    JsonTypes: type[enum.Enum]
+    BoolFormats: type[enum.Enum]
     identifier_cases: tuple[IdentifierCase, ...]
     supported_ref_cases: frozenset[IdentifierCase]
     modifier_combinations: tuple[ModifierCombination, ...]
@@ -1026,6 +1028,28 @@ class Language(Protocol):
         collections expose a single-member enum whose only option is
         ``ERROR``.  Languages with richer strategies (e.g. Rust's
         ``TAGGED_ENUM``) expose additional members.
+        """
+        ...  # pylint: disable=unnecessary-ellipsis
+
+    @property
+    def json_types(self) -> type[enum.Enum]:
+        """Enum class whose members list the JSON value-type options
+        this language supports.
+
+        Languages without a JSON value-type representation expose an
+        empty enum so consumers can enumerate options uniformly without
+        reflection.
+        """
+        ...  # pylint: disable=unnecessary-ellipsis
+
+    @property
+    def bool_formats(self) -> type[enum.Enum]:
+        """Enum class whose members list the boolean format options
+        this language supports.
+
+        Languages without alternative boolean formats expose an empty
+        enum so consumers can enumerate options uniformly without
+        reflection.
         """
         ...  # pylint: disable=unnecessary-ellipsis
 

--- a/src/literalizer/languages/ada.py
+++ b/src/literalizer/languages/ada.py
@@ -506,6 +506,16 @@ class Ada(metaclass=LanguageCls):
 
     heterogeneous_strategies = HeterogeneousStrategies
 
+    class JsonTypes(enum.Enum):
+        """Empty: this language has no JSON value-type variants."""
+
+    json_types = JsonTypes
+
+    class BoolFormats(enum.Enum):
+        """Empty: this language has no alternative boolean formats."""
+
+    bool_formats = BoolFormats
+
     class VersionFormats(enum.Enum):
         """Version options for Ada."""
 

--- a/src/literalizer/languages/bash.py
+++ b/src/literalizer/languages/bash.py
@@ -466,6 +466,16 @@ class Bash(metaclass=LanguageCls):
 
     heterogeneous_strategies = HeterogeneousStrategies
 
+    class JsonTypes(enum.Enum):
+        """Empty: this language has no JSON value-type variants."""
+
+    json_types = JsonTypes
+
+    class BoolFormats(enum.Enum):
+        """Empty: this language has no alternative boolean formats."""
+
+    bool_formats = BoolFormats
+
     class VersionFormats(enum.Enum):
         """Version options for Bash."""
 

--- a/src/literalizer/languages/c.py
+++ b/src/literalizer/languages/c.py
@@ -914,6 +914,16 @@ class C(metaclass=LanguageCls):
 
     heterogeneous_strategies = HeterogeneousStrategies
 
+    class JsonTypes(enum.Enum):
+        """Empty: this language has no JSON value-type variants."""
+
+    json_types = JsonTypes
+
+    class BoolFormats(enum.Enum):
+        """Empty: this language has no alternative boolean formats."""
+
+    bool_formats = BoolFormats
+
     class VersionFormats(enum.Enum):
         """Version options for C."""
 

--- a/src/literalizer/languages/clojure.py
+++ b/src/literalizer/languages/clojure.py
@@ -363,6 +363,16 @@ class Clojure(metaclass=LanguageCls):
 
     heterogeneous_strategies = HeterogeneousStrategies
 
+    class JsonTypes(enum.Enum):
+        """Empty: this language has no JSON value-type variants."""
+
+    json_types = JsonTypes
+
+    class BoolFormats(enum.Enum):
+        """Empty: this language has no alternative boolean formats."""
+
+    bool_formats = BoolFormats
+
     class VersionFormats(enum.Enum):
         """Version options for Clojure."""
 

--- a/src/literalizer/languages/cobol.py
+++ b/src/literalizer/languages/cobol.py
@@ -577,6 +577,16 @@ class Cobol(metaclass=LanguageCls):
 
     heterogeneous_strategies = HeterogeneousStrategies
 
+    class JsonTypes(enum.Enum):
+        """Empty: this language has no JSON value-type variants."""
+
+    json_types = JsonTypes
+
+    class BoolFormats(enum.Enum):
+        """Empty: this language has no alternative boolean formats."""
+
+    bool_formats = BoolFormats
+
     class VersionFormats(enum.Enum):
         """Version options for COBOL."""
 

--- a/src/literalizer/languages/common_lisp.py
+++ b/src/literalizer/languages/common_lisp.py
@@ -380,6 +380,16 @@ class CommonLisp(metaclass=LanguageCls):
 
     heterogeneous_strategies = HeterogeneousStrategies
 
+    class JsonTypes(enum.Enum):
+        """Empty: this language has no JSON value-type variants."""
+
+    json_types = JsonTypes
+
+    class BoolFormats(enum.Enum):
+        """Empty: this language has no alternative boolean formats."""
+
+    bool_formats = BoolFormats
+
     class VersionFormats(enum.Enum):
         """Version options for Common Lisp."""
 

--- a/src/literalizer/languages/cpp.py
+++ b/src/literalizer/languages/cpp.py
@@ -1767,6 +1767,11 @@ class Cpp(metaclass=LanguageCls):
 
     heterogeneous_strategies = HeterogeneousStrategies
 
+    class BoolFormats(enum.Enum):
+        """Empty: this language has no alternative boolean formats."""
+
+    bool_formats = BoolFormats
+
     class VersionFormats(enum.Enum):
         """Version options for C++."""
 

--- a/src/literalizer/languages/crystal.py
+++ b/src/literalizer/languages/crystal.py
@@ -699,6 +699,11 @@ class Crystal(metaclass=LanguageCls):
 
     heterogeneous_strategies = HeterogeneousStrategies
 
+    class BoolFormats(enum.Enum):
+        """Empty: this language has no alternative boolean formats."""
+
+    bool_formats = BoolFormats
+
     class VersionFormats(enum.Enum):
         """Version options for Crystal."""
 

--- a/src/literalizer/languages/csharp.py
+++ b/src/literalizer/languages/csharp.py
@@ -909,6 +909,11 @@ class CSharp(metaclass=LanguageCls):
 
     heterogeneous_strategies = HeterogeneousStrategies
 
+    class BoolFormats(enum.Enum):
+        """Empty: this language has no alternative boolean formats."""
+
+    bool_formats = BoolFormats
+
     class VersionFormats(enum.Enum):
         """Version options for C#."""
 

--- a/src/literalizer/languages/d.py
+++ b/src/literalizer/languages/d.py
@@ -800,6 +800,11 @@ class D(metaclass=LanguageCls):
 
     heterogeneous_strategies = HeterogeneousStrategies
 
+    class BoolFormats(enum.Enum):
+        """Empty: this language has no alternative boolean formats."""
+
+    bool_formats = BoolFormats
+
     class VersionFormats(enum.Enum):
         """Version options for D."""
 

--- a/src/literalizer/languages/dart.py
+++ b/src/literalizer/languages/dart.py
@@ -714,6 +714,16 @@ class Dart(metaclass=LanguageCls):
 
     heterogeneous_strategies = HeterogeneousStrategies
 
+    class JsonTypes(enum.Enum):
+        """Empty: this language has no JSON value-type variants."""
+
+    json_types = JsonTypes
+
+    class BoolFormats(enum.Enum):
+        """Empty: this language has no alternative boolean formats."""
+
+    bool_formats = BoolFormats
+
     class VersionFormats(enum.Enum):
         """Version options for Dart."""
 

--- a/src/literalizer/languages/dhall.py
+++ b/src/literalizer/languages/dhall.py
@@ -841,6 +841,16 @@ class Dhall(metaclass=LanguageCls):
 
     heterogeneous_strategies = HeterogeneousStrategies
 
+    class JsonTypes(enum.Enum):
+        """Empty: this language has no JSON value-type variants."""
+
+    json_types = JsonTypes
+
+    class BoolFormats(enum.Enum):
+        """Empty: this language has no alternative boolean formats."""
+
+    bool_formats = BoolFormats
+
     class VersionFormats(enum.Enum):
         """Version options for Dhall."""
 

--- a/src/literalizer/languages/elixir.py
+++ b/src/literalizer/languages/elixir.py
@@ -513,6 +513,16 @@ class Elixir(metaclass=LanguageCls):
 
     heterogeneous_strategies = HeterogeneousStrategies
 
+    class JsonTypes(enum.Enum):
+        """Empty: this language has no JSON value-type variants."""
+
+    json_types = JsonTypes
+
+    class BoolFormats(enum.Enum):
+        """Empty: this language has no alternative boolean formats."""
+
+    bool_formats = BoolFormats
+
     class VersionFormats(enum.Enum):
         """Version options for Elixir."""
 

--- a/src/literalizer/languages/elm.py
+++ b/src/literalizer/languages/elm.py
@@ -988,6 +988,11 @@ class Elm(metaclass=LanguageCls):
 
     heterogeneous_strategies = HeterogeneousStrategies
 
+    class BoolFormats(enum.Enum):
+        """Empty: this language has no alternative boolean formats."""
+
+    bool_formats = BoolFormats
+
     class VersionFormats(enum.Enum):
         """Version options for Elm."""
 

--- a/src/literalizer/languages/erlang.py
+++ b/src/literalizer/languages/erlang.py
@@ -560,6 +560,11 @@ class Erlang(metaclass=LanguageCls):
 
     heterogeneous_strategies = HeterogeneousStrategies
 
+    class BoolFormats(enum.Enum):
+        """Empty: this language has no alternative boolean formats."""
+
+    bool_formats = BoolFormats
+
     class VersionFormats(enum.Enum):
         """Version options for Erlang."""
 

--- a/src/literalizer/languages/forth.py
+++ b/src/literalizer/languages/forth.py
@@ -469,6 +469,16 @@ class Forth(metaclass=LanguageCls):
 
     heterogeneous_strategies = HeterogeneousStrategies
 
+    class JsonTypes(enum.Enum):
+        """Empty: this language has no JSON value-type variants."""
+
+    json_types = JsonTypes
+
+    class BoolFormats(enum.Enum):
+        """Empty: this language has no alternative boolean formats."""
+
+    bool_formats = BoolFormats
+
     class VersionFormats(enum.Enum):
         """Version options for Forth."""
 

--- a/src/literalizer/languages/fortran.py
+++ b/src/literalizer/languages/fortran.py
@@ -652,6 +652,16 @@ class Fortran(metaclass=LanguageCls):
 
     heterogeneous_strategies = HeterogeneousStrategies
 
+    class JsonTypes(enum.Enum):
+        """Empty: this language has no JSON value-type variants."""
+
+    json_types = JsonTypes
+
+    class BoolFormats(enum.Enum):
+        """Empty: this language has no alternative boolean formats."""
+
+    bool_formats = BoolFormats
+
     class VersionFormats(enum.Enum):
         """Version options for Fortran.
 

--- a/src/literalizer/languages/fsharp.py
+++ b/src/literalizer/languages/fsharp.py
@@ -746,6 +746,11 @@ class FSharp(metaclass=LanguageCls):
 
     heterogeneous_strategies = HeterogeneousStrategies
 
+    class BoolFormats(enum.Enum):
+        """Empty: this language has no alternative boolean formats."""
+
+    bool_formats = BoolFormats
+
     class VersionFormats(enum.Enum):
         """Version options for F#."""
 

--- a/src/literalizer/languages/gleam.py
+++ b/src/literalizer/languages/gleam.py
@@ -1023,6 +1023,11 @@ class Gleam(metaclass=LanguageCls):
 
     heterogeneous_strategies = HeterogeneousStrategies
 
+    class BoolFormats(enum.Enum):
+        """Empty: this language has no alternative boolean formats."""
+
+    bool_formats = BoolFormats
+
     class VersionFormats(enum.Enum):
         """Version options for Gleam."""
 

--- a/src/literalizer/languages/go.py
+++ b/src/literalizer/languages/go.py
@@ -647,6 +647,16 @@ class Go(metaclass=LanguageCls):
 
     heterogeneous_strategies = HeterogeneousStrategies
 
+    class JsonTypes(enum.Enum):
+        """Empty: this language has no JSON value-type variants."""
+
+    json_types = JsonTypes
+
+    class BoolFormats(enum.Enum):
+        """Empty: this language has no alternative boolean formats."""
+
+    bool_formats = BoolFormats
+
     class VersionFormats(enum.Enum):
         """Version options for Go."""
 

--- a/src/literalizer/languages/groovy.py
+++ b/src/literalizer/languages/groovy.py
@@ -410,6 +410,16 @@ class Groovy(metaclass=LanguageCls):
 
     heterogeneous_strategies = HeterogeneousStrategies
 
+    class JsonTypes(enum.Enum):
+        """Empty: this language has no JSON value-type variants."""
+
+    json_types = JsonTypes
+
+    class BoolFormats(enum.Enum):
+        """Empty: this language has no alternative boolean formats."""
+
+    bool_formats = BoolFormats
+
     class VersionFormats(enum.Enum):
         """Version options for Groovy."""
 

--- a/src/literalizer/languages/haskell.py
+++ b/src/literalizer/languages/haskell.py
@@ -1583,6 +1583,11 @@ class Haskell(metaclass=LanguageCls):
 
     heterogeneous_strategies = HeterogeneousStrategies
 
+    class BoolFormats(enum.Enum):
+        """Empty: this language has no alternative boolean formats."""
+
+    bool_formats = BoolFormats
+
     class JsonTypes(enum.Enum):
         """JSON value type options for Haskell."""
 

--- a/src/literalizer/languages/haxe.py
+++ b/src/literalizer/languages/haxe.py
@@ -539,6 +539,16 @@ class Haxe(metaclass=LanguageCls):
 
     heterogeneous_strategies = HeterogeneousStrategies
 
+    class JsonTypes(enum.Enum):
+        """Empty: this language has no JSON value-type variants."""
+
+    json_types = JsonTypes
+
+    class BoolFormats(enum.Enum):
+        """Empty: this language has no alternative boolean formats."""
+
+    bool_formats = BoolFormats
+
     class VersionFormats(enum.Enum):
         """Version options for Haxe."""
 

--- a/src/literalizer/languages/hcl.py
+++ b/src/literalizer/languages/hcl.py
@@ -413,6 +413,16 @@ class Hcl(metaclass=LanguageCls):
 
     heterogeneous_strategies = HeterogeneousStrategies
 
+    class JsonTypes(enum.Enum):
+        """Empty: this language has no JSON value-type variants."""
+
+    json_types = JsonTypes
+
+    class BoolFormats(enum.Enum):
+        """Empty: this language has no alternative boolean formats."""
+
+    bool_formats = BoolFormats
+
     class VersionFormats(enum.Enum):
         """Version options for HCL."""
 

--- a/src/literalizer/languages/java.py
+++ b/src/literalizer/languages/java.py
@@ -1117,6 +1117,11 @@ class Java(metaclass=LanguageCls):
 
     heterogeneous_strategies = HeterogeneousStrategies
 
+    class BoolFormats(enum.Enum):
+        """Empty: this language has no alternative boolean formats."""
+
+    bool_formats = BoolFormats
+
     class JsonTypes(enum.Enum):
         """JSON value type options for Java."""
 

--- a/src/literalizer/languages/javascript.py
+++ b/src/literalizer/languages/javascript.py
@@ -489,6 +489,16 @@ class JavaScript(metaclass=LanguageCls):
 
     heterogeneous_strategies = HeterogeneousStrategies
 
+    class JsonTypes(enum.Enum):
+        """Empty: this language has no JSON value-type variants."""
+
+    json_types = JsonTypes
+
+    class BoolFormats(enum.Enum):
+        """Empty: this language has no alternative boolean formats."""
+
+    bool_formats = BoolFormats
+
     class VersionFormats(enum.Enum):
         """Version options for JavaScript."""
 

--- a/src/literalizer/languages/json5.py
+++ b/src/literalizer/languages/json5.py
@@ -367,6 +367,16 @@ class Json5(metaclass=LanguageCls):
 
     heterogeneous_strategies = HeterogeneousStrategies
 
+    class JsonTypes(enum.Enum):
+        """Empty: this language has no JSON value-type variants."""
+
+    json_types = JsonTypes
+
+    class BoolFormats(enum.Enum):
+        """Empty: this language has no alternative boolean formats."""
+
+    bool_formats = BoolFormats
+
     class VersionFormats(enum.Enum):
         """Version options for JSON5."""
 

--- a/src/literalizer/languages/jsonnet.py
+++ b/src/literalizer/languages/jsonnet.py
@@ -394,6 +394,16 @@ class Jsonnet(metaclass=LanguageCls):
 
     heterogeneous_strategies = HeterogeneousStrategies
 
+    class JsonTypes(enum.Enum):
+        """Empty: this language has no JSON value-type variants."""
+
+    json_types = JsonTypes
+
+    class BoolFormats(enum.Enum):
+        """Empty: this language has no alternative boolean formats."""
+
+    bool_formats = BoolFormats
+
     class VersionFormats(enum.Enum):
         """Version options for Jsonnet."""
 

--- a/src/literalizer/languages/julia.py
+++ b/src/literalizer/languages/julia.py
@@ -501,6 +501,16 @@ class Julia(metaclass=LanguageCls):
 
     heterogeneous_strategies = HeterogeneousStrategies
 
+    class JsonTypes(enum.Enum):
+        """Empty: this language has no JSON value-type variants."""
+
+    json_types = JsonTypes
+
+    class BoolFormats(enum.Enum):
+        """Empty: this language has no alternative boolean formats."""
+
+    bool_formats = BoolFormats
+
     class VersionFormats(enum.Enum):
         """Version options for Julia."""
 

--- a/src/literalizer/languages/kotlin.py
+++ b/src/literalizer/languages/kotlin.py
@@ -1246,6 +1246,11 @@ class Kotlin(metaclass=LanguageCls):
 
     heterogeneous_strategies = HeterogeneousStrategies
 
+    class BoolFormats(enum.Enum):
+        """Empty: this language has no alternative boolean formats."""
+
+    bool_formats = BoolFormats
+
     class JsonTypes(enum.Enum):
         """JSON value type options for Kotlin."""
 

--- a/src/literalizer/languages/lua.py
+++ b/src/literalizer/languages/lua.py
@@ -413,6 +413,16 @@ class Lua(metaclass=LanguageCls):
 
     heterogeneous_strategies = HeterogeneousStrategies
 
+    class JsonTypes(enum.Enum):
+        """Empty: this language has no JSON value-type variants."""
+
+    json_types = JsonTypes
+
+    class BoolFormats(enum.Enum):
+        """Empty: this language has no alternative boolean formats."""
+
+    bool_formats = BoolFormats
+
     class VersionFormats(enum.Enum):
         """Version options for Lua."""
 

--- a/src/literalizer/languages/matlab.py
+++ b/src/literalizer/languages/matlab.py
@@ -489,6 +489,16 @@ class Matlab(metaclass=LanguageCls):
 
     heterogeneous_strategies = HeterogeneousStrategies
 
+    class JsonTypes(enum.Enum):
+        """Empty: this language has no JSON value-type variants."""
+
+    json_types = JsonTypes
+
+    class BoolFormats(enum.Enum):
+        """Empty: this language has no alternative boolean formats."""
+
+    bool_formats = BoolFormats
+
     class VersionFormats(enum.Enum):
         """Version options for MATLAB."""
 

--- a/src/literalizer/languages/mojo.py
+++ b/src/literalizer/languages/mojo.py
@@ -1225,6 +1225,16 @@ class Mojo(metaclass=LanguageCls):
 
     heterogeneous_strategies = HeterogeneousStrategies
 
+    class JsonTypes(enum.Enum):
+        """Empty: this language has no JSON value-type variants."""
+
+    json_types = JsonTypes
+
+    class BoolFormats(enum.Enum):
+        """Empty: this language has no alternative boolean formats."""
+
+    bool_formats = BoolFormats
+
     class VersionFormats(enum.Enum):
         """Version options for Mojo."""
 

--- a/src/literalizer/languages/nim.py
+++ b/src/literalizer/languages/nim.py
@@ -1106,6 +1106,11 @@ class Nim(metaclass=LanguageCls):
 
     heterogeneous_strategies = HeterogeneousStrategies
 
+    class BoolFormats(enum.Enum):
+        """Empty: this language has no alternative boolean formats."""
+
+    bool_formats = BoolFormats
+
     class VersionFormats(enum.Enum):
         """Version options for Nim."""
 

--- a/src/literalizer/languages/nix.py
+++ b/src/literalizer/languages/nix.py
@@ -434,6 +434,16 @@ class Nix(metaclass=LanguageCls):
 
     heterogeneous_strategies = HeterogeneousStrategies
 
+    class JsonTypes(enum.Enum):
+        """Empty: this language has no JSON value-type variants."""
+
+    json_types = JsonTypes
+
+    class BoolFormats(enum.Enum):
+        """Empty: this language has no alternative boolean formats."""
+
+    bool_formats = BoolFormats
+
     class VersionFormats(enum.Enum):
         """Version options for Nix."""
 

--- a/src/literalizer/languages/norg.py
+++ b/src/literalizer/languages/norg.py
@@ -342,6 +342,16 @@ class Norg(metaclass=LanguageCls):
 
     heterogeneous_strategies = HeterogeneousStrategies
 
+    class JsonTypes(enum.Enum):
+        """Empty: this language has no JSON value-type variants."""
+
+    json_types = JsonTypes
+
+    class BoolFormats(enum.Enum):
+        """Empty: this language has no alternative boolean formats."""
+
+    bool_formats = BoolFormats
+
     class VersionFormats(enum.Enum):
         """Version options for Norg."""
 

--- a/src/literalizer/languages/objective_c.py
+++ b/src/literalizer/languages/objective_c.py
@@ -586,6 +586,16 @@ class ObjectiveC(metaclass=LanguageCls):
 
     heterogeneous_strategies = HeterogeneousStrategies
 
+    class JsonTypes(enum.Enum):
+        """Empty: this language has no JSON value-type variants."""
+
+    json_types = JsonTypes
+
+    class BoolFormats(enum.Enum):
+        """Empty: this language has no alternative boolean formats."""
+
+    bool_formats = BoolFormats
+
     class VersionFormats(enum.Enum):
         """Version options for Objective-C."""
 

--- a/src/literalizer/languages/ocaml.py
+++ b/src/literalizer/languages/ocaml.py
@@ -647,6 +647,11 @@ class OCaml(metaclass=LanguageCls):
 
     heterogeneous_strategies = HeterogeneousStrategies
 
+    class BoolFormats(enum.Enum):
+        """Empty: this language has no alternative boolean formats."""
+
+    bool_formats = BoolFormats
+
     class VersionFormats(enum.Enum):
         """Version options for OCaml."""
 

--- a/src/literalizer/languages/occam.py
+++ b/src/literalizer/languages/occam.py
@@ -388,6 +388,16 @@ class Occam(metaclass=LanguageCls):
 
     heterogeneous_strategies = HeterogeneousStrategies
 
+    class JsonTypes(enum.Enum):
+        """Empty: this language has no JSON value-type variants."""
+
+    json_types = JsonTypes
+
+    class BoolFormats(enum.Enum):
+        """Empty: this language has no alternative boolean formats."""
+
+    bool_formats = BoolFormats
+
     class VersionFormats(enum.Enum):
         """Version options for Occam."""
 

--- a/src/literalizer/languages/odin.py
+++ b/src/literalizer/languages/odin.py
@@ -615,6 +615,16 @@ class Odin(metaclass=LanguageCls):
 
     heterogeneous_strategies = HeterogeneousStrategies
 
+    class JsonTypes(enum.Enum):
+        """Empty: this language has no JSON value-type variants."""
+
+    json_types = JsonTypes
+
+    class BoolFormats(enum.Enum):
+        """Empty: this language has no alternative boolean formats."""
+
+    bool_formats = BoolFormats
+
     class VersionFormats(enum.Enum):
         """Version options for Odin."""
 

--- a/src/literalizer/languages/perl.py
+++ b/src/literalizer/languages/perl.py
@@ -635,6 +635,11 @@ class Perl(metaclass=LanguageCls):
 
     heterogeneous_strategies = HeterogeneousStrategies
 
+    class JsonTypes(enum.Enum):
+        """Empty: this language has no JSON value-type variants."""
+
+    json_types = JsonTypes
+
     class VersionFormats(enum.Enum):
         """Version options for Perl."""
 

--- a/src/literalizer/languages/php.py
+++ b/src/literalizer/languages/php.py
@@ -466,6 +466,16 @@ class Php(metaclass=LanguageCls):
 
     heterogeneous_strategies = HeterogeneousStrategies
 
+    class JsonTypes(enum.Enum):
+        """Empty: this language has no JSON value-type variants."""
+
+    json_types = JsonTypes
+
+    class BoolFormats(enum.Enum):
+        """Empty: this language has no alternative boolean formats."""
+
+    bool_formats = BoolFormats
+
     class VersionFormats(enum.Enum):
         """Version options for PHP."""
 

--- a/src/literalizer/languages/powershell.py
+++ b/src/literalizer/languages/powershell.py
@@ -424,6 +424,16 @@ class PowerShell(metaclass=LanguageCls):
 
     heterogeneous_strategies = HeterogeneousStrategies
 
+    class JsonTypes(enum.Enum):
+        """Empty: this language has no JSON value-type variants."""
+
+    json_types = JsonTypes
+
+    class BoolFormats(enum.Enum):
+        """Empty: this language has no alternative boolean formats."""
+
+    bool_formats = BoolFormats
+
     class VersionFormats(enum.Enum):
         """Version options for PowerShell."""
 

--- a/src/literalizer/languages/purescript.py
+++ b/src/literalizer/languages/purescript.py
@@ -1114,6 +1114,11 @@ class PureScript(metaclass=LanguageCls):
 
     heterogeneous_strategies = HeterogeneousStrategies
 
+    class BoolFormats(enum.Enum):
+        """Empty: this language has no alternative boolean formats."""
+
+    bool_formats = BoolFormats
+
     class JsonTypes(enum.Enum):
         """JSON value type options for PureScript."""
 

--- a/src/literalizer/languages/python.py
+++ b/src/literalizer/languages/python.py
@@ -1233,6 +1233,16 @@ class Python(metaclass=LanguageCls):
 
     heterogeneous_strategies = HeterogeneousStrategies
 
+    class JsonTypes(enum.Enum):
+        """Empty: this language has no JSON value-type variants."""
+
+    json_types = JsonTypes
+
+    class BoolFormats(enum.Enum):
+        """Empty: this language has no alternative boolean formats."""
+
+    bool_formats = BoolFormats
+
     class VersionFormats(enum.Enum):
         """Python version to target.
 

--- a/src/literalizer/languages/r.py
+++ b/src/literalizer/languages/r.py
@@ -458,6 +458,16 @@ class R(metaclass=LanguageCls):
 
     heterogeneous_strategies = HeterogeneousStrategies
 
+    class JsonTypes(enum.Enum):
+        """Empty: this language has no JSON value-type variants."""
+
+    json_types = JsonTypes
+
+    class BoolFormats(enum.Enum):
+        """Empty: this language has no alternative boolean formats."""
+
+    bool_formats = BoolFormats
+
     class VersionFormats(enum.Enum):
         """Version options for R."""
 

--- a/src/literalizer/languages/racket.py
+++ b/src/literalizer/languages/racket.py
@@ -368,6 +368,16 @@ class Racket(metaclass=LanguageCls):
 
     heterogeneous_strategies = HeterogeneousStrategies
 
+    class JsonTypes(enum.Enum):
+        """Empty: this language has no JSON value-type variants."""
+
+    json_types = JsonTypes
+
+    class BoolFormats(enum.Enum):
+        """Empty: this language has no alternative boolean formats."""
+
+    bool_formats = BoolFormats
+
     class VersionFormats(enum.Enum):
         """Version options for Racket."""
 

--- a/src/literalizer/languages/raku.py
+++ b/src/literalizer/languages/raku.py
@@ -491,6 +491,16 @@ class Raku(metaclass=LanguageCls):
 
     heterogeneous_strategies = HeterogeneousStrategies
 
+    class JsonTypes(enum.Enum):
+        """Empty: this language has no JSON value-type variants."""
+
+    json_types = JsonTypes
+
+    class BoolFormats(enum.Enum):
+        """Empty: this language has no alternative boolean formats."""
+
+    bool_formats = BoolFormats
+
     class VersionFormats(enum.Enum):
         """Version options for Raku."""
 

--- a/src/literalizer/languages/roc.py
+++ b/src/literalizer/languages/roc.py
@@ -822,6 +822,16 @@ class Roc(metaclass=LanguageCls):
 
     heterogeneous_strategies = HeterogeneousStrategies
 
+    class JsonTypes(enum.Enum):
+        """Empty: this language has no JSON value-type variants."""
+
+    json_types = JsonTypes
+
+    class BoolFormats(enum.Enum):
+        """Empty: this language has no alternative boolean formats."""
+
+    bool_formats = BoolFormats
+
     class VersionFormats(enum.Enum):
         """Version options for Roc."""
 

--- a/src/literalizer/languages/ruby.py
+++ b/src/literalizer/languages/ruby.py
@@ -515,6 +515,16 @@ class Ruby(metaclass=LanguageCls):
 
     heterogeneous_strategies = HeterogeneousStrategies
 
+    class JsonTypes(enum.Enum):
+        """Empty: this language has no JSON value-type variants."""
+
+    json_types = JsonTypes
+
+    class BoolFormats(enum.Enum):
+        """Empty: this language has no alternative boolean formats."""
+
+    bool_formats = BoolFormats
+
     class VersionFormats(enum.Enum):
         """Version options for Ruby."""
 

--- a/src/literalizer/languages/rust.py
+++ b/src/literalizer/languages/rust.py
@@ -1997,6 +1997,11 @@ class Rust(metaclass=LanguageCls):
 
     heterogeneous_strategies = HeterogeneousStrategies
 
+    class BoolFormats(enum.Enum):
+        """Empty: this language has no alternative boolean formats."""
+
+    bool_formats = BoolFormats
+
     class VersionFormats(enum.Enum):
         """Version options for Rust."""
 

--- a/src/literalizer/languages/scala.py
+++ b/src/literalizer/languages/scala.py
@@ -834,6 +834,11 @@ class Scala(metaclass=LanguageCls):
 
     heterogeneous_strategies = HeterogeneousStrategies
 
+    class BoolFormats(enum.Enum):
+        """Empty: this language has no alternative boolean formats."""
+
+    bool_formats = BoolFormats
+
     class VersionFormats(enum.Enum):
         """Version options for Scala."""
 

--- a/src/literalizer/languages/scheme.py
+++ b/src/literalizer/languages/scheme.py
@@ -363,6 +363,16 @@ class Scheme(metaclass=LanguageCls):
 
     heterogeneous_strategies = HeterogeneousStrategies
 
+    class JsonTypes(enum.Enum):
+        """Empty: this language has no JSON value-type variants."""
+
+    json_types = JsonTypes
+
+    class BoolFormats(enum.Enum):
+        """Empty: this language has no alternative boolean formats."""
+
+    bool_formats = BoolFormats
+
     class VersionFormats(enum.Enum):
         """Version options for Scheme."""
 

--- a/src/literalizer/languages/sml.py
+++ b/src/literalizer/languages/sml.py
@@ -649,6 +649,16 @@ class Sml(metaclass=LanguageCls):
 
     heterogeneous_strategies = HeterogeneousStrategies
 
+    class JsonTypes(enum.Enum):
+        """Empty: this language has no JSON value-type variants."""
+
+    json_types = JsonTypes
+
+    class BoolFormats(enum.Enum):
+        """Empty: this language has no alternative boolean formats."""
+
+    bool_formats = BoolFormats
+
     class VersionFormats(enum.Enum):
         """Version options for SML."""
 

--- a/src/literalizer/languages/swift.py
+++ b/src/literalizer/languages/swift.py
@@ -885,6 +885,16 @@ class Swift(metaclass=LanguageCls):
 
     heterogeneous_strategies = HeterogeneousStrategies
 
+    class JsonTypes(enum.Enum):
+        """Empty: this language has no JSON value-type variants."""
+
+    json_types = JsonTypes
+
+    class BoolFormats(enum.Enum):
+        """Empty: this language has no alternative boolean formats."""
+
+    bool_formats = BoolFormats
+
     class VersionFormats(enum.Enum):
         """Version options for Swift."""
 

--- a/src/literalizer/languages/systemverilog.py
+++ b/src/literalizer/languages/systemverilog.py
@@ -533,6 +533,16 @@ class SystemVerilog(metaclass=LanguageCls):
 
     heterogeneous_strategies = HeterogeneousStrategies
 
+    class JsonTypes(enum.Enum):
+        """Empty: this language has no JSON value-type variants."""
+
+    json_types = JsonTypes
+
+    class BoolFormats(enum.Enum):
+        """Empty: this language has no alternative boolean formats."""
+
+    bool_formats = BoolFormats
+
     class VersionFormats(enum.Enum):
         """Version options for SystemVerilog."""
 

--- a/src/literalizer/languages/tcl.py
+++ b/src/literalizer/languages/tcl.py
@@ -421,6 +421,16 @@ class Tcl(metaclass=LanguageCls):
 
     heterogeneous_strategies = HeterogeneousStrategies
 
+    class JsonTypes(enum.Enum):
+        """Empty: this language has no JSON value-type variants."""
+
+    json_types = JsonTypes
+
+    class BoolFormats(enum.Enum):
+        """Empty: this language has no alternative boolean formats."""
+
+    bool_formats = BoolFormats
+
     class VersionFormats(enum.Enum):
         """Version options for Tcl."""
 

--- a/src/literalizer/languages/toml.py
+++ b/src/literalizer/languages/toml.py
@@ -380,6 +380,16 @@ class Toml(metaclass=LanguageCls):
 
     heterogeneous_strategies = HeterogeneousStrategies
 
+    class JsonTypes(enum.Enum):
+        """Empty: this language has no JSON value-type variants."""
+
+    json_types = JsonTypes
+
+    class BoolFormats(enum.Enum):
+        """Empty: this language has no alternative boolean formats."""
+
+    bool_formats = BoolFormats
+
     class VersionFormats(enum.Enum):
         """Version options for TOML."""
 

--- a/src/literalizer/languages/typescript.py
+++ b/src/literalizer/languages/typescript.py
@@ -829,6 +829,16 @@ class TypeScript(metaclass=LanguageCls):
 
     heterogeneous_strategies = HeterogeneousStrategies
 
+    class JsonTypes(enum.Enum):
+        """Empty: this language has no JSON value-type variants."""
+
+    json_types = JsonTypes
+
+    class BoolFormats(enum.Enum):
+        """Empty: this language has no alternative boolean formats."""
+
+    bool_formats = BoolFormats
+
     class VersionFormats(enum.Enum):
         """Version options for TypeScript."""
 

--- a/src/literalizer/languages/v.py
+++ b/src/literalizer/languages/v.py
@@ -850,6 +850,16 @@ class V(metaclass=LanguageCls):
 
     heterogeneous_strategies = HeterogeneousStrategies
 
+    class JsonTypes(enum.Enum):
+        """Empty: this language has no JSON value-type variants."""
+
+    json_types = JsonTypes
+
+    class BoolFormats(enum.Enum):
+        """Empty: this language has no alternative boolean formats."""
+
+    bool_formats = BoolFormats
+
     class VersionFormats(enum.Enum):
         """Version options for V."""
 

--- a/src/literalizer/languages/vb.py
+++ b/src/literalizer/languages/vb.py
@@ -549,6 +549,16 @@ class VisualBasic(metaclass=LanguageCls):
 
     heterogeneous_strategies = HeterogeneousStrategies
 
+    class JsonTypes(enum.Enum):
+        """Empty: this language has no JSON value-type variants."""
+
+    json_types = JsonTypes
+
+    class BoolFormats(enum.Enum):
+        """Empty: this language has no alternative boolean formats."""
+
+    bool_formats = BoolFormats
+
     class VersionFormats(enum.Enum):
         """Version options for Visual Basic."""
 

--- a/src/literalizer/languages/wren.py
+++ b/src/literalizer/languages/wren.py
@@ -445,6 +445,16 @@ class Wren(metaclass=LanguageCls):
 
     heterogeneous_strategies = HeterogeneousStrategies
 
+    class JsonTypes(enum.Enum):
+        """Empty: this language has no JSON value-type variants."""
+
+    json_types = JsonTypes
+
+    class BoolFormats(enum.Enum):
+        """Empty: this language has no alternative boolean formats."""
+
+    bool_formats = BoolFormats
+
     class VersionFormats(enum.Enum):
         """Version options for Wren."""
 

--- a/src/literalizer/languages/yaml.py
+++ b/src/literalizer/languages/yaml.py
@@ -349,6 +349,16 @@ class Yaml(metaclass=LanguageCls):
 
     heterogeneous_strategies = HeterogeneousStrategies
 
+    class JsonTypes(enum.Enum):
+        """Empty: this language has no JSON value-type variants."""
+
+    json_types = JsonTypes
+
+    class BoolFormats(enum.Enum):
+        """Empty: this language has no alternative boolean formats."""
+
+    bool_formats = BoolFormats
+
     class VersionFormats(enum.Enum):
         """Version options for YAML."""
 

--- a/src/literalizer/languages/zig.py
+++ b/src/literalizer/languages/zig.py
@@ -790,6 +790,11 @@ class Zig(metaclass=LanguageCls):
 
     heterogeneous_strategies = HeterogeneousStrategies
 
+    class BoolFormats(enum.Enum):
+        """Empty: this language has no alternative boolean formats."""
+
+    bool_formats = BoolFormats
+
     class VersionFormats(enum.Enum):
         """Version options for Zig."""
 

--- a/tests/metadata/test_class_enum_access.py
+++ b/tests/metadata/test_class_enum_access.py
@@ -31,6 +31,8 @@ def test_format_enums_populated(*, language_cls: LanguageCls) -> None:
     assert len(language_cls.StringFormats) >= 1
     assert len(language_cls.TrailingCommas) >= 1
     assert len(language_cls.CallStyles) >= 0
+    assert len(language_cls.JsonTypes) >= 0
+    assert len(language_cls.BoolFormats) >= 0
     assert len(language_cls.identifier_cases) >= 1
     assert isinstance(language_cls.supports_zero_parameter_calls, bool)
     assert isinstance(language_cls.supports_inline_multiline_dict_args, bool)


### PR DESCRIPTION
## Summary

- Declares nested `JsonTypes` and `BoolFormats` enums (plus snake_case `json_types` / `bool_formats` aliases) on every `Language` subclass, using empty enums for languages without variants.
- Adds matching `JsonTypes` / `BoolFormats` type declarations to the `LanguageCls` metaclass and `json_types` / `bool_formats` properties to the `Language` Protocol so consumers can enumerate options uniformly without reflection helpers.
- Extends `test_class_enum_access.py` to assert presence of both attributes across all 64 languages, and adds a `newsfragments/2755.change` entry.
- Suppresses pyright on the one existing `Scala.JsonTypes.CIRCE` script access whose narrowing the new metaclass annotation changes (matching the established `# pyright: ignore` pattern used for `V.HeterogeneousStrategies`).

Resolves #2755.

## Test plan

- [x] `uv run --extra dev pytest tests/metadata tests/test_languages.py tests/test_meta.py` (545 passed)
- [x] Pre-commit hooks (ruff, pylint manual, pyright, mypy, ty, pyrefly) pass on the modified files and on push

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> API/metadata expansion with empty enums where unsupported; no change to literalization behavior beyond the Scala script alias.
> 
> **Overview**
> Every **`Language`** subclass now exposes nested **`JsonTypes`** and **`BoolFormats`** enums, with snake_case **`json_types`** / **`bool_formats`** aliases matching other format enums. Languages without JSON value-type or alternate boolean options get **empty** enums so callers can enumerate capabilities uniformly instead of using reflection.
> 
> The **`Language`** protocol and **`LanguageCls`** metaclass declare these types and properties; metadata tests assert both enums exist on all languages. The Scala CI roundtrip script is updated to use **`Scala.json_types.CIRCE`**. Dev dependencies pin **`toml-fmt-common==1.3.2`** to avoid a **`pyproject-fmt`** breakage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7c847dd76cc84e6db04f5be1a9cbadf155abb5f3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->