### PR TITLE
Add Scheme JSON round-trip check (#2677)

### DIFF
--- a/.github/scripts/run_scheme_roundtrip.py
+++ b/.github/scripts/run_scheme_roundtrip.py
@@ -2,15 +2,15 @@
 
 Literalize the shared ``roundtrip_input.json`` document to a Scheme
 ``(define my-data ...)`` binding, wrap it in a Guile script that
-normalizes the literalized value into a hash-table / vector tree and
-prints ``scm->json`` of that tree, run it under ``guile-3.0``, and hand
-the emitted JSON to :func:`roundtrip_common.verify`.
+normalizes the literalized value into the alist / vector tree
+``scm->json`` expects, run it under ``guile-3.0``, and hand the emitted
+JSON to :func:`roundtrip_common.verify`.
 
 This lives here, driven by the ``Scheme roundtrip`` step of the
 ``lint-fast`` job in ``.github/workflows/lint.yml``, because that job is
-where ``guile-3.0`` and the ``guile-json`` apt package are installed.
-It shares the same input and comparison logic as the other per-language
-round-trip helpers.
+where ``guile-3.0`` and the ``guile-3.0-json`` apt package are
+installed.  It shares the same input and comparison logic as the other
+per-language round-trip helpers.
 
 The serializer is the ``(json)`` module from guile-json rather than a
 hand-rolled encoder (matching the preference expressed in the issue
@@ -24,10 +24,12 @@ To avoid emitting one ``list-ref`` per leaf (as the Tcl / Common Lisp
 helpers do), Python instead emits a compact *shape tree* describing
 which subtrees of ``my-data`` are objects and which are arrays, plus a
 generic Scheme ``normalize`` walker that rebuilds the typed structure
-``scm->json`` expects: hash tables for objects, vectors for arrays.
-Shape nodes are ``(obj (key . sub-shape) ...)``, ``(arr sub-shape ...)``,
-or the leaf symbol ``scalar``.  All JSON encoding -- string escaping,
-number formatting, separator placement -- is then done by a single
+``scm->json`` accepts: an *alist* of ``(key . value)`` pairs for each
+object (``scm->json``'s ``json-valid?`` rejects hash tables, see
+``builder.scm:188``), and a vector for each array.  Shape nodes are
+``(obj (key . sub-shape) ...)``, ``(arr sub-shape ...)``, or the leaf
+symbol ``scalar``.  All JSON encoding -- string escaping, number
+formatting, separator placement -- is then done by a single
 ``scm->json`` call, so no encoder details are hand-rolled.  No
 top-level keys are excluded: Guile has arbitrary-precision integers
 (so the 26-digit ``biginteger`` survives) and ``scm->json`` emits
@@ -64,9 +66,13 @@ _LABEL = "Scheme"
 # Python verifier regardless of the runner's locale.  The `normalize`
 # walker pairs each shape node with the matching sub-value inside the
 # literalized `my-data`: an `obj` shape consumes the flat alternating
-# key/value list (taking the value at every odd index), an `arr` shape
-# walks its children in lockstep with the literalized list, and the
-# `scalar` leaf passes the value straight through to `scm->json`.
+# key/value list (taking the value at every odd index) and returns an
+# alist of `(key . value)` pairs (the only object form `scm->json`'s
+# `json-valid?` accepts; see `json/builder.scm:188`), an `arr` shape
+# walks its children in lockstep with the literalized list and returns
+# a vector, and the `scalar` leaf passes the value straight through to
+# `scm->json`.  Indexing is done with hand-rolled accumulators so the
+# walker has no implicit dependency on SRFI-1 (`iota`).
 _HEADER = """\
 (use-modules (json))
 (set-port-encoding! (current-output-port) "UTF-8")
@@ -75,20 +81,24 @@ _HEADER = """\
   (cond
     ((eq? shape (quote scalar)) data)
     ((eq? (car shape) (quote obj))
-     (let ((ht (make-hash-table)))
-       (let loop ((entries (cdr shape)) (index 0))
-         (when (pair? entries)
-           (hash-set! ht
-                      (car (car entries))
-                      (normalize (cdr (car entries))
-                                 (list-ref data (+ (* index 2) 1))))
-           (loop (cdr entries) (+ index 1))))
-       ht))
+     (let loop ((entries (cdr shape)) (index 0) (acc (quote ())))
+       (if (pair? entries)
+           (loop (cdr entries)
+                 (+ index 1)
+                 (cons (cons (car (car entries))
+                             (normalize (cdr (car entries))
+                                        (list-ref data
+                                                  (+ (* index 2) 1))))
+                       acc))
+           (reverse acc))))
     ((eq? (car shape) (quote arr))
-     (list->vector
-      (map (lambda (child index) (normalize child (list-ref data index)))
-           (cdr shape)
-           (iota (length (cdr shape))))))))
+     (let loop ((children (cdr shape)) (index 0) (acc (quote ())))
+       (if (pair? children)
+           (loop (cdr children)
+                 (+ index 1)
+                 (cons (normalize (car children) (list-ref data index))
+                       acc))
+           (list->vector (reverse acc)))))))
 """
 
 

--- a/.github/scripts/run_scheme_roundtrip.py
+++ b/.github/scripts/run_scheme_roundtrip.py
@@ -1,0 +1,158 @@
+"""Scheme JSON round-trip check (issue #2677).
+
+Literalize the shared ``roundtrip_input.json`` document to a Scheme
+``(define my-data ...)`` binding, wrap it in a Guile script that
+normalizes the literalized value into a hash-table / vector tree and
+prints ``scm->json`` of that tree, run it under ``guile-3.0``, and hand
+the emitted JSON to :func:`roundtrip_common.verify`.
+
+This lives here, driven by the ``Scheme roundtrip`` step of the
+``lint-fast`` job in ``.github/workflows/lint.yml``, because that job is
+where ``guile-3.0`` and the ``guile-json`` apt package are installed.
+It shares the same input and comparison logic as the other per-language
+round-trip helpers.
+
+The serializer is the ``(json)`` module from guile-json rather than a
+hand-rolled encoder (matching the preference expressed in the issue
+notes); Guile itself ships no JSON library.  The literalized Scheme
+output is shape-ambiguous: a dict becomes ``(list "k" v ...)`` and an
+array becomes ``(list v ...)``; both an empty dict and an empty array
+literalize to ``(list)``.  A purely runtime encoder therefore cannot
+tell ``{}`` from ``[]``.
+
+To avoid emitting one ``list-ref`` per leaf (as the Tcl / Common Lisp
+helpers do), Python instead emits a compact *shape tree* describing
+which subtrees of ``my-data`` are objects and which are arrays, plus a
+generic Scheme ``normalize`` walker that rebuilds the typed structure
+``scm->json`` expects: hash tables for objects, vectors for arrays.
+Shape nodes are ``(obj (key . sub-shape) ...)``, ``(arr sub-shape ...)``,
+or the leaf symbol ``scalar``.  All JSON encoding -- string escaping,
+number formatting, separator placement -- is then done by a single
+``scm->json`` call, so no encoder details are hand-rolled.  No
+top-level keys are excluded: Guile has arbitrary-precision integers
+(so the 26-digit ``biginteger`` survives) and ``scm->json`` emits
+inexact reals via ``number->string``, which round-trips
+``1.7976931348623157e+308``; ``-0.0`` compares equal to ``0.0`` under
+the parsed-value diff in :func:`roundtrip_common.verify`.
+"""
+
+import json
+import shutil
+
+import roundtrip_common
+
+from literalizer.languages import Scheme
+
+# `json.loads` returns this recursive shape; typing the walker against
+# it lets `isinstance` narrow cleanly under pyright, pyrefly, and ty
+# without `cast`.
+type JsonValue = (
+    None
+    | bool
+    | int
+    | float
+    | str
+    | list["JsonValue"]
+    | dict[str, "JsonValue"]
+)
+
+_VAR_NAME = "my-data"
+_LABEL = "Scheme"
+
+# `set-port-encoding!` pins stdout to UTF-8 so unicode string leaves
+# (e.g. ``"unicode é 中"``) survive the byte-level handoff to the
+# Python verifier regardless of the runner's locale.  The `normalize`
+# walker pairs each shape node with the matching sub-value inside the
+# literalized `my-data`: an `obj` shape consumes the flat alternating
+# key/value list (taking the value at every odd index), an `arr` shape
+# walks its children in lockstep with the literalized list, and the
+# `scalar` leaf passes the value straight through to `scm->json`.
+_HEADER = """\
+(use-modules (json))
+(set-port-encoding! (current-output-port) "UTF-8")
+
+(define (normalize shape data)
+  (cond
+    ((eq? shape (quote scalar)) data)
+    ((eq? (car shape) (quote obj))
+     (let ((ht (make-hash-table)))
+       (let loop ((entries (cdr shape)) (index 0))
+         (when (pair? entries)
+           (hash-set! ht
+                      (car (car entries))
+                      (normalize (cdr (car entries))
+                                 (list-ref data (+ (* index 2) 1))))
+           (loop (cdr entries) (+ index 1))))
+       ht))
+    ((eq? (car shape) (quote arr))
+     (list->vector
+      (map (lambda (child index) (normalize child (list-ref data index)))
+           (cdr shape)
+           (iota (length (cdr shape))))))))
+"""
+
+
+def _scheme_string(text: str) -> str:
+    """Return a Scheme string literal whose value is *text*."""
+    escaped = text.replace("\\", "\\\\").replace('"', '\\"')
+    return f'"{escaped}"'
+
+
+def _shape(value: JsonValue) -> str:
+    """Return a Scheme datum describing the JSON shape of *value*.
+
+    Leaves render as the symbol ``scalar``; objects as
+    ``(obj ("k" . sub-shape) ...)``; arrays as ``(arr sub-shape ...)``.
+    The walker in ``_HEADER`` consumes this tree in lockstep with the
+    literalized ``my-data``.
+    """
+    if isinstance(value, dict):
+        entries = " ".join(
+            f"({_scheme_string(text=key)} . {_shape(value=sub)})"
+            for key, sub in value.items()
+        )
+        return f"(obj {entries})"
+    if isinstance(value, list):
+        children = " ".join(_shape(value=item) for item in value)
+        return f"(arr {children})"
+    return "scalar"
+
+
+def _build_program(json_text: str) -> str:
+    """Return a runnable Scheme program literalized from *json_text*."""
+    result = roundtrip_common.literalize_new_variable(
+        language=Scheme(),
+        json_text=json_text,
+        var_name=_VAR_NAME,
+        pre_indent_level=0,
+    )
+    preamble = "\n".join((*result.preamble, *result.body_preamble))
+    shape_datum = _shape(value=json.loads(s=json_text))
+    emit = f"(scm->json (normalize (quote {shape_datum}) {_VAR_NAME}))"
+    return f"{_HEADER}\n{preamble}\n{result.code}\n{emit}\n"
+
+
+def main() -> None:
+    """Round-trip the shared document through the Scheme backend."""
+    program = _build_program(json_text=roundtrip_common.read_input())
+    # Invoke `guile-3.0` directly rather than `guile` because the
+    # `Install apt packages` step does not replay the package's
+    # `update-alternatives` postinst on cache hit, so `/usr/bin/guile`
+    # is missing (mirrors the `Lint Scheme` step).
+    guile = shutil.which(cmd="guile-3.0") or "guile-3.0"
+    roundtrip_common.execute(
+        label=_LABEL,
+        source_filename="main.scm",
+        program=program,
+        steps=[
+            roundtrip_common.Step(
+                args=[guile, "--no-auto-compile", "-s", "main.scm"],
+                failure_label="guile runtime error",
+            ),
+        ],
+        excluded_keys=(),
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/run_scheme_roundtrip.py
+++ b/.github/scripts/run_scheme_roundtrip.py
@@ -7,9 +7,10 @@ normalizes the literalized value into the alist / vector tree
 JSON to :func:`roundtrip_common.verify`.
 
 This lives here, driven by the ``Scheme roundtrip`` step of the
-``lint-fast`` job in ``.github/workflows/lint.yml``, because that job is
-where ``guile-3.0`` and the ``guile-3.0-json`` apt package are
-installed.  It shares the same input and comparison logic as the other
+``lint-fast`` job in ``.github/workflows/lint.yml``, because that job
+is where ``guile-3.0`` is installed and where the ``Install guile-json``
+step clones the guile-json checkout that ``LITERALIZER_GUILE_JSON_PATH``
+points at.  It shares the same input and comparison logic as the other
 per-language round-trip helpers.
 
 The serializer is the ``(json)`` module from guile-json rather than a
@@ -39,6 +40,7 @@ the parsed-value diff in :func:`roundtrip_common.verify`.
 """
 
 import json
+import os
 import shutil
 
 import roundtrip_common
@@ -150,13 +152,27 @@ def main() -> None:
     # `update-alternatives` postinst on cache hit, so `/usr/bin/guile`
     # is missing (mirrors the `Lint Scheme` step).
     guile = shutil.which(cmd="guile-3.0") or "guile-3.0"
+    # `LITERALIZER_GUILE_JSON_PATH` points at the guile-json checkout
+    # (the `Install guile-json` step in `.github/workflows/lint.yml`
+    # exports it).  Adding it via `-L` puts `json.scm` on Guile's
+    # source-load path so the bare `(use-modules (json))` resolves
+    # there; `--no-auto-compile` keeps the run from trying to write
+    # a `.go` cache for it.
+    guile_json_path = os.environ["LITERALIZER_GUILE_JSON_PATH"]
     roundtrip_common.execute(
         label=_LABEL,
         source_filename="main.scm",
         program=program,
         steps=[
             roundtrip_common.Step(
-                args=[guile, "--no-auto-compile", "-s", "main.scm"],
+                args=[
+                    guile,
+                    "--no-auto-compile",
+                    "-L",
+                    guile_json_path,
+                    "-s",
+                    "main.scm",
+                ],
                 failure_label="guile runtime error",
             ),
         ],

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -123,15 +123,19 @@ jobs:
       # is for reproducibility rather than language selection. apt
       # provides no point-release pin, so the ``-3.0`` package suffix
       # is the only available version constraint.
-      # ``guile-json`` (pinned to the Ubuntu 24.04 build of ``4.7.3-3``)
+      # ``guile-3-json`` (pinned to the Ubuntu 24.04 build of ``4.7.3-3``)
       # provides the ``(json)`` module used by
       # ``.github/scripts/run_scheme_roundtrip.py`` to re-emit JSON from
       # a literalized Scheme value; Guile itself ships no JSON library.
+      # Note the package name is ``guile-3-json`` (binding the module to
+      # the Guile 3.0 site-load path), not the unversioned ``guile-json``
+      # apt package, which installs the module under the Guile 2.2 site
+      # path where ``guile-3.0`` cannot find it.
       - name: Install apt packages
         uses: awalsh128/cache-apt-pkgs-action@v1
         with:
           packages: tcl=8.6.14build1 tcllib=1.21+dfsg-1 gforth=0.7.3+dfsg-9build4.1
-            guile-3.0 guile-json=4.7.3-3
+            guile-3.0 guile-3-json=4.7.3-3
           version: 1.0
       # The Forth Foundation Library (FFL) supplies the ``jos`` JSON
       # output-stream module used by

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -123,11 +123,15 @@ jobs:
       # is for reproducibility rather than language selection. apt
       # provides no point-release pin, so the ``-3.0`` package suffix
       # is the only available version constraint.
+      # ``guile-json`` (pinned to the Ubuntu 24.04 build of ``4.7.3-3``)
+      # provides the ``(json)`` module used by
+      # ``.github/scripts/run_scheme_roundtrip.py`` to re-emit JSON from
+      # a literalized Scheme value; Guile itself ships no JSON library.
       - name: Install apt packages
         uses: awalsh128/cache-apt-pkgs-action@v1
         with:
           packages: tcl=8.6.14build1 tcllib=1.21+dfsg-1 gforth=0.7.3+dfsg-9build4.1
-            guile-3.0
+            guile-3.0 guile-json=4.7.3-3
           version: 1.0
       # The Forth Foundation Library (FFL) supplies the ``jos`` JSON
       # output-stream module used by
@@ -455,6 +459,14 @@ jobs:
         run: |-
           find tests/integration/cases -name '*.scm' -print0 > /tmp/files-scheme && test -s /tmp/files-scheme
           xargs -0 -P "$(nproc)" -I{} guile-3.0 --no-auto-compile -s {} < /tmp/files-scheme
+
+      # Basic JSON -> Scheme -> JSON round-trip (issue 1867). Runs here
+      # because this is the job with the `guile-3.0` toolchain on PATH;
+      # `uv run` (project mode, not `--no-project`) is required so
+      # `import literalizer` resolves.
+      # See `.github/scripts/run_scheme_roundtrip.py`.
+      - name: Scheme roundtrip
+        run: uv run python .github/scripts/run_scheme_roundtrip.py
 
       - name: Lint Dhall
         run: |-

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -123,19 +123,20 @@ jobs:
       # is for reproducibility rather than language selection. apt
       # provides no point-release pin, so the ``-3.0`` package suffix
       # is the only available version constraint.
-      # ``guile-3-json`` (pinned to the Ubuntu 24.04 build of ``4.7.3-3``)
-      # provides the ``(json)`` module used by
+      # ``guile-3.0-json`` (pinned to the Ubuntu 24.04 build of
+      # ``4.7.3-3``) provides the ``(json)`` module used by
       # ``.github/scripts/run_scheme_roundtrip.py`` to re-emit JSON from
       # a literalized Scheme value; Guile itself ships no JSON library.
-      # Note the package name is ``guile-3-json`` (binding the module to
-      # the Guile 3.0 site-load path), not the unversioned ``guile-json``
-      # apt package, which installs the module under the Guile 2.2 site
-      # path where ``guile-3.0`` cannot find it.
+      # Note the package name is ``guile-3.0-json`` (binding the module
+      # to the Guile 3.0 site-load path, matching the ``guile-3.0``
+      # binary's naming), not the unversioned ``guile-json`` apt package
+      # which installs the module under the Guile 2.2 site path where
+      # ``guile-3.0`` cannot find it.
       - name: Install apt packages
         uses: awalsh128/cache-apt-pkgs-action@v1
         with:
           packages: tcl=8.6.14build1 tcllib=1.21+dfsg-1 gforth=0.7.3+dfsg-9build4.1
-            guile-3.0 guile-3-json=4.7.3-3
+            guile-3.0 guile-3.0-json=4.7.3-3
           version: 1.0
       # The Forth Foundation Library (FFL) supplies the ``jos`` JSON
       # output-stream module used by

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -123,20 +123,11 @@ jobs:
       # is for reproducibility rather than language selection. apt
       # provides no point-release pin, so the ``-3.0`` package suffix
       # is the only available version constraint.
-      # ``guile-3.0-json`` (pinned to the Ubuntu 24.04 build of
-      # ``4.7.3-3``) provides the ``(json)`` module used by
-      # ``.github/scripts/run_scheme_roundtrip.py`` to re-emit JSON from
-      # a literalized Scheme value; Guile itself ships no JSON library.
-      # Note the package name is ``guile-3.0-json`` (binding the module
-      # to the Guile 3.0 site-load path, matching the ``guile-3.0``
-      # binary's naming), not the unversioned ``guile-json`` apt package
-      # which installs the module under the Guile 2.2 site path where
-      # ``guile-3.0`` cannot find it.
       - name: Install apt packages
         uses: awalsh128/cache-apt-pkgs-action@v1
         with:
           packages: tcl=8.6.14build1 tcllib=1.21+dfsg-1 gforth=0.7.3+dfsg-9build4.1
-            guile-3.0 guile-3.0-json=4.7.3-3
+            guile-3.0
           version: 1.0
       # The Forth Foundation Library (FFL) supplies the ``jos`` JSON
       # output-stream module used by
@@ -151,6 +142,20 @@ jobs:
           git clone https://github.com/irdvo/ffl.git /tmp/ffl
           git -C /tmp/ffl checkout --quiet 753d418081a48afe8c86196261fda3299d93ac98
           echo "LITERALIZER_FFL_PATH=/tmp/ffl" >> "$GITHUB_ENV"
+      # guile-json supplies the ``(json)`` module used by
+      # ``.github/scripts/run_scheme_roundtrip.py``; Guile itself ships
+      # no JSON library, and the apt-packaged variants on Ubuntu 24.04
+      # are an unreliable source (the ``guile-json`` binary targets
+      # Guile 2.2, no Guile-3.0-bound binary is published under either
+      # ``guile-3-json`` or ``guile-3.0-json``).  Pin the upstream source
+      # tag instead and pass the checkout to ``guile`` via ``-L`` from
+      # the round-trip script; ``--no-auto-compile`` means no .go cache
+      # build is needed.  Tag ``4.7.3`` is the latest upstream release.
+      - name: Install guile-json
+        run: |-
+          git clone https://github.com/aconchillo/guile-json.git /tmp/guile-json
+          git -C /tmp/guile-json checkout --quiet 4.7.3
+          echo "LITERALIZER_GUILE_JSON_PATH=/tmp/guile-json" >> "$GITHUB_ENV"
       - name: Install Dhall
         # The pinned ``dhall-haskell`` 1.42.2 binary implements Dhall
         # language standard 23.1.0, which is ``>=`` the ``V17`` (Dhall

--- a/newsfragments/2677.change
+++ b/newsfragments/2677.change
@@ -1,0 +1,1 @@
+Add a Scheme JSON round-trip check to CI using the shared round-trip fixture, driven by Guile 3 and the ``guile-json`` library.


### PR DESCRIPTION
## Summary

- Adds `.github/scripts/run_scheme_roundtrip.py`, which literalizes the shared `roundtrip_input.json` to a `(define my-data ...)` Scheme binding and re-emits JSON via guile-json's `scm->json` to verify the parsed output matches the original document.
- Because Scheme's dict format is a flat alternating `(list "k" v ...)` (indistinguishable from a heterogeneous list, and `(list)` for both empty dicts and empty arrays), Python emits a compact shape tree (`obj` / `arr` / `scalar`) and the program ships a generic `normalize` walker that rebuilds the literalized data into the hash-table / vector tree `scm->json` expects — no encoder details are hand-rolled.
- Pins `guile-json=4.7.3-3` in the `lint-fast` apt step (Guile ships no JSON library) and adds a `Scheme roundtrip` step next to the existing `Lint Scheme` step in `.github/workflows/lint.yml`, plus a towncrier `newsfragments/2677.change`.
- Follow-ups filed: #2760 (add `Scheme(json_type=GUILE_JSON)` so the script can drop the walker and call `scm->json` directly) and #2761 (switch the dict format to an alist of cons pairs to remove the local ambiguity).

## Test plan

- [ ] CI `lint-fast` → `Scheme roundtrip` step exits 0 and prints `Scheme round-trip OK`.
- [ ] CI `lint-fast` → `Lint Scheme` step still passes (no fixture regressions from the new apt pin).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds CI-only scripting and workflow steps; no runtime product, auth, or data-path changes.
> 
> **Overview**
> Adds **Scheme** to the shared JSON round-trip CI checks: a new helper literalizes `roundtrip_input.json` to Guile, rebuilds object/array structure via a Python-generated **shape tree** and embedded `normalize` (because literalized dicts and arrays are ambiguous lists), then serializes with **guile-json** `scm->json`.
> 
> **Workflow** changes clone **guile-json** tag `4.7.3` into `/tmp/guile-json`, export `LITERALIZER_GUILE_JSON_PATH`, and run `uv run python .github/scripts/run_scheme_roundtrip.py` in `lint-fast` after `Lint Scheme`. A towncrier entry documents the addition.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 496b1d047bfa92d8f6db0ac52cff7c5f2deed421. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->