### PR TITLE
Add C(json_type=CJSON) for cJSON tree rendering

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1569,6 +1569,11 @@ jobs:
           cache-dependency-glob: '**/pyproject.toml'
       - name: Install clang-tidy
         run: uv tool install clang-tidy
+      # ``cJSON`` fixtures (``C(json_type=CJSON)``) need the
+      # ``<cjson/cJSON.h>`` header on the default include path;
+      # clang-tidy parses the headers even though it never links.
+      - name: Install libcjson-dev
+        run: sudo apt-get update && sudo apt-get install -y libcjson-dev
       # ``-std=c99`` matches ``C.language_version`` in
       # ``src/literalizer/languages/c.py``; keep them in sync.
       - name: Run clang-tidy on C files

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -485,28 +485,32 @@ jobs:
       - name: Wren roundtrip
         run: uv run python .github/scripts/run_wren_roundtrip.py
 
+      # cJSON drives the generated ``main`` in the ``C(json_type=CJSON)``
+      # goldens linted just below and in the C round-trip step further
+      # down: both paths emit ``cJSON_Create*`` / ``cJSON_AddItemTo*``
+      # calls and need the header on the include path and ``-lcjson`` on
+      # the link line.
+      - name: Install libcjson-dev
+        run: sudo apt-get update && sudo apt-get install -y libcjson-dev
+
       # Each fixture defines its own main, so compile and run directly.
       # The build-and-run step also surfaces any syntax errors, so a
       # separate `-fsyntax-only` pass would be redundant.
       # ``-std=c99`` matches ``C.language_version`` in
       # ``src/literalizer/languages/c.py``; keep them in sync.
+      # ``-lcjson`` resolves the cJSON references in
+      # ``C(json_type=CJSON)`` goldens; other fixtures link cleanly
+      # against it as an unused library.
       - name: Lint C
         run: |-
           find tests/integration/cases -name '*.c' -print0 > /tmp/files-c && test -s /tmp/files-c
           cat > /tmp/run-c.sh <<'SCRIPT'
           tmpdir=$(mktemp -d)
           trap 'rm -rf "$tmpdir"' EXIT
-          clang -std=c99 "$1" -o "$tmpdir/run" || exit 1
+          clang -std=c99 "$1" -lcjson -o "$tmpdir/run" || exit 1
           "$tmpdir/run" || exit 1
           SCRIPT
           xargs -0 -P "$(nproc)" -n1 bash /tmp/run-c.sh < /tmp/files-c
-
-      # cJSON drives the generated ``main`` in the C round-trip step
-      # below: the literalized ``CVal`` is untagged, so the helper
-      # builds a parallel ``cJSON`` tree (shape generated from the
-      # parsed JSON) and prints it with ``cJSON_PrintUnformatted``.
-      - name: Install libcjson-dev
-        run: sudo apt-get update && sudo apt-get install -y libcjson-dev
 
       # Basic JSON -> C -> JSON round-trip (issue 1867). Runs here
       # because this is the job with the C toolchain (``clang``) set up

--- a/newsfragments/2766.change
+++ b/newsfragments/2766.change
@@ -1,0 +1,1 @@
+Add ``C(json_type=CJSON)`` to render values as cJSON trees built with ``cJSON_Create*`` and ``cJSON_AddItemTo*`` calls.

--- a/spelling_private_dict.txt
+++ b/spelling_private_dict.txt
@@ -126,6 +126,7 @@ backticks
 beartype
 bool
 booleans
+cJSON
 chrono
 closers
 commonjs

--- a/src/literalizer/languages/c.py
+++ b/src/literalizer/languages/c.py
@@ -679,7 +679,7 @@ def _c_cjson_call_stub(
     The cJSON-mode counterpart of :func:`_c_call_stub`: every parameter
     and value-returning return type is ``cJSON *`` instead of the
     tagged ``CVal`` union, and a value-returning stub returns ``NULL``
-    rather than a zero-initialised ``CVal`` literal.
+    rather than a zero-initialized ``CVal`` literal.
     """
     # pylint: disable=too-complex,too-many-branches
     is_value = stub_return is StubReturn.VALUE

--- a/src/literalizer/languages/c.py
+++ b/src/literalizer/languages/c.py
@@ -667,6 +667,87 @@ _CJSON_STATIC_PREAMBLE: tuple[str, ...] = ("#include <cjson/cJSON.h>",)
 
 
 @beartype
+def _c_cjson_call_stub(
+    parts: Sequence[str],
+    params: Sequence[str],
+    stub_return: StubReturn,
+    _args: Sequence[Value],
+    /,
+) -> tuple[str, ...]:
+    """Return cJSON-mode C stub declarations for a call name.
+
+    The cJSON-mode counterpart of :func:`_c_call_stub`: every parameter
+    and value-returning return type is ``cJSON *`` instead of the
+    tagged ``CVal`` union, and a value-returning stub returns ``NULL``
+    rather than a zero-initialised ``CVal`` literal.
+    """
+    # pylint: disable=too-complex,too-many-branches
+    is_value = stub_return is StubReturn.VALUE
+    return_keyword = "cJSON *" if is_value else "void "
+    proto = ", ".join(["cJSON *"] * len(params)) if params else "void"
+    stub_params = ", ".join(f"cJSON *_a{i}" for i in range(len(params)))
+    stub_signature = stub_params or "void"
+    discards = "".join(f" (void)_a{i};" for i in range(len(params)))
+    return_stmt = " return NULL;" if is_value else ""
+    has_body = discards or is_value
+    stub_body = f"{{{discards}{return_stmt} }}" if has_body else "{}"
+    nolint = (
+        ("// NOLINTNEXTLINE(bugprone-easily-swappable-parameters)",)
+        if len(params) > _SWAPPABLE_PARAMS_NOLINT_THRESHOLD
+        else ()
+    )
+    match parts:
+        case [single]:
+            return (
+                *nolint,
+                f"static {return_keyword}{single}({stub_signature}) "
+                f"{stub_body}",
+            )
+        case [root, method]:
+            stub_fn = f"{root}_{method}_stub_"
+            type_name = f"{root}Type_"
+            return (
+                *nolint,
+                f"static {return_keyword}{stub_fn}({stub_signature}) "
+                f"{stub_body}",
+                f"struct {type_name} "
+                f"{{ {return_keyword}(*{method})({proto}); }};",
+                f"static const struct {type_name} {root} = "
+                f"{{ .{method} = {stub_fn} }};",
+            )
+        case _:
+            pass
+    root = parts[0]
+    method = parts[-1]
+    fields = parts[1:-1]
+    stub_fn = "_".join((*parts, "stub_"))
+    lines: list[str] = [
+        *nolint,
+        f"static {return_keyword}{stub_fn}({stub_signature}) {stub_body}",
+    ]
+    inner_type = f"{fields[-1]}Type_"
+    lines.append(
+        f"struct {inner_type} {{ {return_keyword}(*{method})({proto}); }};",
+    )
+    prev_type = inner_type
+    for i in range(len(fields) - 2, -1, -1):
+        curr_type = f"{fields[i]}Type_"
+        lines.append(
+            f"struct {curr_type} {{ struct {prev_type} {fields[i + 1]}; }};",
+        )
+        prev_type = curr_type
+    root_type = f"{root}Type_"
+    lines.append(
+        f"struct {root_type} {{ struct {prev_type} {fields[0]}; }};",
+    )
+    init = f"{{ .{method} = {stub_fn} }}"
+    for field in reversed(fields):
+        init = f"{{ .{field} = {init} }}"
+    lines.append(f"static const struct {root_type} {root} = {init};")
+    return tuple(lines)
+
+
+@beartype
 @dataclasses.dataclass(frozen=True)
 class _CjsonRender:
     """Multi-statement cJSON build plus the rendered right-hand side.
@@ -1477,7 +1558,14 @@ class C(metaclass=LanguageCls):
         [Sequence[str], Sequence[str], StubReturn, Sequence[Value]],
         tuple[str, ...],
     ]:
-        """Return file-scope stubs for a call expression."""
+        """Return file-scope stubs for a call expression.
+
+        Under :attr:`json_type` every parameter is a ``cJSON *`` rather
+        than the tagged ``CVal`` union, since call arguments are emitted
+        as ``cJSON_Create*`` expressions.
+        """
+        if self._json_type_active:
+            return _c_cjson_call_stub
         return _c_call_stub
 
     @cached_property
@@ -1536,8 +1624,43 @@ class C(metaclass=LanguageCls):
     def format_call_arg(self) -> Callable[[Value, str], str]:
         """Wrap each call argument in the ``CVal`` union so call sites
         match the concrete prototype emitted by :func:`_c_call_stub`.
+
+        Under :attr:`json_type` each scalar call argument is rendered
+        as a ``cJSON_Create*`` expression matching the ``cJSON *``
+        parameters emitted by :func:`_c_cjson_call_stub`.
         """
+        if self._json_type_active:
+            return self._cjson_format_call_arg
         return self._format_entry
+
+    @cached_property
+    def _cjson_format_call_arg(self) -> Callable[[Value, str], str]:
+        """Return the cJSON-mode call-argument formatter."""
+        format_integer = self.format_integer
+        format_float = self.format_float
+        format_string = self.format_string
+        format_bytes = self.format_bytes
+        format_date = self.format_date
+        format_datetime = self.format_datetime
+        format_time = self.format_time
+        datetime_epoch = self.datetime_format.value.type_produced is int
+
+        @beartype
+        def _format(value: Value, _formatted: str) -> str:
+            """Render *value* as a ``cJSON_Create*`` expression."""
+            return _cjson_format_scalar(
+                value=value,
+                format_integer=format_integer,
+                format_float=format_float,
+                format_string=format_string,
+                format_bytes=format_bytes,
+                format_date=format_date,
+                format_datetime=format_datetime,
+                format_time=format_time,
+                datetime_epoch=datetime_epoch,
+            )
+
+        return _format
 
     @cached_property
     def format_string(self) -> Callable[[str], str]:

--- a/src/literalizer/languages/c.py
+++ b/src/literalizer/languages/c.py
@@ -92,7 +92,10 @@ from literalizer._language import (
     prepend_body_preamble,
 )
 from literalizer._types import OrderedMap, Scalar, Value
-from literalizer.exceptions import UnrepresentableInputError
+from literalizer.exceptions import (
+    IncompatibleFormatsError,
+    UnrepresentableInputError,
+)
 
 
 @beartype
@@ -605,6 +608,22 @@ def _c_call_stub(
 
 
 @beartype
+def _format_c_cjson_call_declaration(
+    name: str,
+    value: str,
+    _data: Value,
+    _modifiers: frozenset[enum.Enum],
+) -> str:
+    """Format a cJSON declaration binding a call result.
+
+    A call returns a freshly-constructed ``cJSON *`` node directly, so
+    the binding is a plain pointer declaration with no node-building
+    statements.
+    """
+    return f"cJSON *{name} = {value};"
+
+
+@beartype
 def _format_c_call_declaration(
     name: str,
     value: str,
@@ -642,6 +661,206 @@ def _format_c_call_assignment(name: str, value: str, _data: Value) -> str:
     assigned directly with no compound-literal wrapping.
     """
     return f"{name} = {value};"
+
+
+_CJSON_STATIC_PREAMBLE: tuple[str, ...] = ("#include <cjson/cJSON.h>",)
+
+
+@beartype
+@dataclasses.dataclass(frozen=True)
+class _CjsonRender:
+    """Multi-statement cJSON build plus the rendered right-hand side.
+
+    *build_statements* are emitted into the function body before the
+    binding line; *binding_rhs* is the C expression that yields the
+    root ``cJSON *``.  The build always names the root ``_n0`` (every
+    other temporary uses the same ``_n<N>`` zero-padded numbering) so
+    that ``compute_body_preamble`` and ``format_variable_declaration``
+    can recompute the same plan from the same data without sharing
+    state.
+    """
+
+    build_statements: tuple[str, ...]
+    binding_rhs: str
+
+
+@beartype
+def _cjson_format_scalar(  # noqa: C901, PLR0911
+    *,
+    value: Value,
+    format_integer: Callable[[int], str],
+    format_float: Callable[[float], str],
+    format_string: Callable[[str], str],
+    format_bytes: Callable[[bytes], str],
+    format_date: Callable[[datetime.date], str],
+    format_datetime: Callable[[datetime.datetime], str],
+    format_time: Callable[[datetime.time], str],
+    datetime_epoch: bool,
+) -> str:
+    """Return the ``cJSON_Create*`` expression for one scalar."""
+    # pylint: disable=too-many-return-statements,too-complex
+    match value:
+        case bool():
+            return f"cJSON_CreateBool({1 if value else 0})"
+        case None:
+            return "cJSON_CreateNull()"
+        case int():
+            return f"cJSON_CreateNumber((double){format_integer(value)})"
+        case float():
+            return f"cJSON_CreateNumber({format_float(value)})"
+        case str():
+            return f"cJSON_CreateString({format_string(value)})"
+        case bytes():
+            return f"cJSON_CreateString({format_bytes(value)})"
+        case datetime.datetime() if datetime_epoch:
+            return f"cJSON_CreateNumber((double){format_datetime(value)})"
+        case datetime.datetime():
+            return f"cJSON_CreateString({format_datetime(value)})"
+        case datetime.date():
+            return f"cJSON_CreateString({format_date(value)})"
+        case datetime.time():
+            return f"cJSON_CreateString({format_time(value)})"
+        case _:
+            msg = (
+                "C(json_type=CJSON) cannot represent value of type "
+                f"{type(value).__name__}"
+            )
+            raise UnrepresentableInputError(msg)
+
+
+@beartype
+def _cjson_walk(
+    *,
+    node: Value,
+    statements: list[str],
+    counter: list[int],
+    name_prefix: str,
+    format_integer: Callable[[int], str],
+    format_float: Callable[[float], str],
+    format_string: Callable[[str], str],
+    format_bytes: Callable[[bytes], str],
+    format_date: Callable[[datetime.date], str],
+    format_datetime: Callable[[datetime.datetime], str],
+    format_time: Callable[[datetime.time], str],
+    datetime_epoch: bool,
+) -> str:
+    """Walk *node* recursively, emitting cJSON build statements.
+
+    Returns the name of the temporary holding the rendered node.  A
+    scalar gets its own ``_nN`` temporary so the binding always
+    references ``_n0`` regardless of root shape.
+    """
+    name = f"{name_prefix}{counter[0]}"
+    counter[0] += 1
+    match node:
+        case dict():
+            statements.append(f"cJSON *{name} = cJSON_CreateObject();")
+            for key, val in node.items():
+                if not isinstance(key, str):
+                    msg = (
+                        "C(json_type=CJSON) can only represent dict keys "
+                        f"as strings, not {type(key).__name__}"
+                    )
+                    raise UnrepresentableInputError(msg)
+                child = _cjson_walk(
+                    node=val,
+                    statements=statements,
+                    counter=counter,
+                    name_prefix=name_prefix,
+                    format_integer=format_integer,
+                    format_float=format_float,
+                    format_string=format_string,
+                    format_bytes=format_bytes,
+                    format_date=format_date,
+                    format_datetime=format_datetime,
+                    format_time=format_time,
+                    datetime_epoch=datetime_epoch,
+                )
+                statements.append(
+                    f"cJSON_AddItemToObject({name}, "
+                    f"{format_string(key)}, {child});"
+                )
+        case list() | set():
+            statements.append(f"cJSON *{name} = cJSON_CreateArray();")
+            items: list[Value] = (
+                sorted(node, key=lambda v: (type(v).__name__, repr(v)))
+                if isinstance(node, set)
+                else list(node)
+            )
+            for item in items:
+                child = _cjson_walk(
+                    node=item,
+                    statements=statements,
+                    counter=counter,
+                    name_prefix=name_prefix,
+                    format_integer=format_integer,
+                    format_float=format_float,
+                    format_string=format_string,
+                    format_bytes=format_bytes,
+                    format_date=format_date,
+                    format_datetime=format_datetime,
+                    format_time=format_time,
+                    datetime_epoch=datetime_epoch,
+                )
+                statements.append(f"cJSON_AddItemToArray({name}, {child});")
+        case _:
+            expr = _cjson_format_scalar(
+                value=node,
+                format_integer=format_integer,
+                format_float=format_float,
+                format_string=format_string,
+                format_bytes=format_bytes,
+                format_date=format_date,
+                format_datetime=format_datetime,
+                format_time=format_time,
+                datetime_epoch=datetime_epoch,
+            )
+            statements.append(f"cJSON *{name} = {expr};")
+    return name
+
+
+@beartype
+def _build_cjson_render(
+    *,
+    data: Value,
+    format_integer: Callable[[int], str],
+    format_float: Callable[[float], str],
+    format_string: Callable[[str], str],
+    format_bytes: Callable[[bytes], str],
+    format_date: Callable[[datetime.date], str],
+    format_datetime: Callable[[datetime.datetime], str],
+    format_time: Callable[[datetime.time], str],
+    datetime_epoch: bool,
+    name_prefix: str,
+) -> _CjsonRender:
+    """Build the cJSON statement plan for *data*.
+
+    Empty containers and bare scalars collapse to a single build
+    statement that binds directly; nothing about the binding line
+    needs to differ.  The *name_prefix* lets callers pick distinct
+    temporary names so a combined declaration + reassignment in one
+    function body does not collide.
+    """
+    statements: list[str] = []
+    counter = [0]
+    _cjson_walk(
+        node=data,
+        statements=statements,
+        counter=counter,
+        name_prefix=name_prefix,
+        format_integer=format_integer,
+        format_float=format_float,
+        format_string=format_string,
+        format_bytes=format_bytes,
+        format_date=format_date,
+        format_datetime=format_datetime,
+        format_time=format_time,
+        datetime_epoch=datetime_epoch,
+    )
+    return _CjsonRender(
+        build_statements=tuple(statements),
+        binding_rhs=f"{name_prefix}0",
+    )
 
 
 @beartype
@@ -915,7 +1134,15 @@ class C(metaclass=LanguageCls):
     heterogeneous_strategies = HeterogeneousStrategies
 
     class JsonTypes(enum.Enum):
-        """Empty: this language has no JSON value-type variants."""
+        """JSON value type options for C."""
+
+        CJSON = "cJSON *"
+        """The ``cJSON`` dynamic JSON value type from the
+        ``cjson/cJSON.h`` library.  Every node is constructed
+        explicitly via ``cJSON_Create*`` calls and assembled with
+        ``cJSON_AddItemToObject`` / ``cJSON_AddItemToArray``; the
+        binding type is ``cJSON *``.
+        """
 
     json_types = JsonTypes
 
@@ -941,6 +1168,30 @@ class C(metaclass=LanguageCls):
     supported_ref_cases: ClassVar[frozenset[IdentifierCase]] = (
         NON_KEBAB_REF_CASES
     )
+
+    def __post_init__(self) -> None:
+        """Reject ``json_type`` combinations the generator cannot emit."""
+        self._validate_json_type_spec()
+
+    def _validate_json_type_spec(self) -> None:
+        """Reject ``json_type`` combinations the generator cannot emit.
+
+        Under :attr:`json_type` the rendered data flows through cJSON
+        node-construction calls.  The ``RECORD`` heterogeneous
+        strategy generates ``struct`` declarations whose literals do
+        not correspond to any cJSON node type, so the two cannot be
+        combined in the first slice.
+        """
+        if not self._json_type_active:
+            return
+        if self.heterogeneous_strategy.name == "RECORD":
+            msg = (
+                "C json_type renders data through cJSON node "
+                "construction calls and is incompatible with "
+                "heterogeneous_strategy=RECORD, which generates "
+                "struct declarations. Use heterogeneous_strategy=ERROR."
+            )
+            raise IncompatibleFormatsError(msg)
 
     def validate_spec_for_data(self, data: Value) -> None:
         """Raise if the spec cannot produce valid C for *data*.
@@ -1044,6 +1295,7 @@ class C(metaclass=LanguageCls):
     heterogeneous_strategy: HeterogeneousStrategies = (
         HeterogeneousStrategies.ERROR
     )
+    json_type: JsonTypes | None = None
     # Keep in sync with the ``-std=`` flag passed to clang and clang-tidy
     # in ``.github/workflows/lint.yml``.
     language_version: VersionFormats = VersionFormats.C99
@@ -1078,6 +1330,11 @@ class C(metaclass=LanguageCls):
     def _record_strategy_active(self) -> bool:
         """Return whether the ``RECORD`` heterogeneous strategy is set."""
         return self.heterogeneous_strategy.name == "RECORD"
+
+    @cached_property
+    def _json_type_active(self) -> bool:
+        """Return whether C should render via the ``cJSON`` API."""
+        return self.json_type is not None
 
     def _c_record_field_type(  # noqa: C901, PLR0911
         self,
@@ -1176,7 +1433,15 @@ class C(metaclass=LanguageCls):
         ``RECORD`` resolves to the shared record behavior (its value
         needs the per-instance renderer, so it cannot be stored on the
         enum member); ``ERROR`` keeps the ``CVal``-union default.
+        Under :attr:`json_type` the framework's scalar checks are
+        skipped because cJSON's dynamic node type accepts any mix of
+        scalar types in a container.
         """
+        if self._json_type_active:
+            return dataclasses.replace(
+                NO_HETEROGENEOUS_BEHAVIOR,
+                skip_scalar_checks=True,
+            )
         if self._record_strategy_active:
             return self._record_strategy.behavior
         return NO_HETEROGENEOUS_BEHAVIOR
@@ -1563,10 +1828,33 @@ class C(metaclass=LanguageCls):
         Under ``RECORD`` a record-shaped root is declared with its
         generated ``struct`` type (``struct Record0 my_data = (struct
         Record0){...};``) and an all-record-list root as an array
-        (``struct Record0 my_data[] = {...};``); every other value keeps
-        the ``CVal``-wrapped form.
+        (``struct Record0 my_data[] = {...};``); under
+        :attr:`json_type` the value is built up by a sequence of
+        ``cJSON_Create*`` / ``cJSON_AddItem*`` statements emitted into
+        the binding's body, with the binding line declaring
+        ``cJSON *NAME = _n0;``; every other value keeps the
+        ``CVal``-wrapped form.
         """
         format_entry = self._format_entry
+        if self._json_type_active:
+            build_render = self._build_cjson_render_for_data
+
+            @beartype
+            def _format_cjson_decl(
+                name: str,
+                _value: str,
+                data: Value,
+                _modifiers: frozenset[enum.Enum],
+            ) -> str:
+                """Format a cJSON declaration as build + bind lines."""
+                render = build_render(data=data, name_prefix="_n")
+                lines = (
+                    *render.build_statements,
+                    f"cJSON *{name} = {render.binding_rhs};",
+                )
+                return "\n".join(lines)
+
+            return _format_cjson_decl
 
         @beartype
         def _format_decl(
@@ -1594,9 +1882,31 @@ class C(metaclass=LanguageCls):
 
         The combined declaration+assignment form is only exercised for a
         top-level record-shaped dict, so a ``RECORD`` reassignment is a
-        plain ``my_data = (struct Record0){...};`` struct copy.
+        plain ``my_data = (struct Record0){...};`` struct copy.  Under
+        :attr:`json_type` the assignment builds a fresh cJSON tree under
+        a distinct ``_m<N>`` prefix so its temporaries do not collide
+        with the declaration's ``_n<N>`` block in the same function
+        body, then rebinds ``NAME`` to the new root.
         """
         format_entry = self._format_entry
+        if self._json_type_active:
+            build_render = self._build_cjson_render_for_data
+
+            @beartype
+            def _format_cjson_assign(
+                name: str,
+                _value: str,
+                data: Value,
+            ) -> str:
+                """Format a cJSON assignment as build + rebind lines."""
+                render = build_render(data=data, name_prefix="_m")
+                lines = (
+                    *render.build_statements,
+                    f"{name} = {render.binding_rhs};",
+                )
+                return "\n".join(lines)
+
+            return _format_cjson_assign
 
         @beartype
         def _format_assign(name: str, value: str, data: Value) -> str:
@@ -1608,6 +1918,26 @@ class C(metaclass=LanguageCls):
             return f"{name} = {wrapped};"
 
         return _format_assign
+
+    def _build_cjson_render_for_data(
+        self, *, data: Value, name_prefix: str
+    ) -> _CjsonRender:
+        """Build a cJSON render plan for *data* using this spec's
+        scalar formatters.
+        """
+        datetime_epoch = self.datetime_format.value.type_produced is int
+        return _build_cjson_render(
+            data=data,
+            format_integer=self.format_integer,
+            format_float=self.format_float,
+            format_string=self.format_string,
+            format_bytes=self.format_bytes,
+            format_date=self.format_date,
+            format_datetime=self.format_datetime,
+            format_time=self.format_time,
+            datetime_epoch=datetime_epoch,
+            name_prefix=name_prefix,
+        )
 
     @cached_property
     def format_call_variable_declaration(
@@ -1621,7 +1951,11 @@ class C(metaclass=LanguageCls):
         always the universal ``CVal`` union (the type every generated
         call stub returns), so the call result is bound directly with a
         plain ``CVal`` declaration and no compound-literal wrapping.
+        Under :attr:`json_type` the binding type is ``cJSON *``
+        instead, matching the cJSON node-construction API.
         """
+        if self._json_type_active:
+            return _format_c_cjson_call_declaration
         return _format_c_call_declaration
 
     @cached_property
@@ -1638,7 +1972,15 @@ class C(metaclass=LanguageCls):
 
     @cached_property
     def static_preamble(self) -> Sequence[str]:
-        """Static preamble lines emitted once per file."""
+        """Static preamble lines emitted once per file.
+
+        Under :attr:`json_type` the ``cjson/cJSON.h`` header replaces
+        the default ``CVal`` / ``CKV`` type declarations because every
+        emitted expression goes through the cJSON node-construction
+        API.
+        """
+        if self._json_type_active:
+            return _CJSON_STATIC_PREAMBLE
         return (
             "#include <stdbool.h>",
             "#include <stddef.h>",

--- a/tests/integration/cases/binary/C_json_type_cjson_binary@c99.c
+++ b/tests/integration/cases/binary/C_json_type_cjson_binary@c99.c
@@ -1,0 +1,9 @@
+#include <cjson/cJSON.h>
+int main(void) {
+cJSON *_n0 = cJSON_CreateArray();
+cJSON *_n1 = cJSON_CreateString("48656c6c6f");
+cJSON_AddItemToArray(_n0, _n1);
+cJSON *my_data = _n0;
+    (void)my_data;
+    return 0;
+}

--- a/tests/integration/cases/bool_list/C_json_type_cjson_bool_list@c99.c
+++ b/tests/integration/cases/bool_list/C_json_type_cjson_bool_list@c99.c
@@ -1,0 +1,13 @@
+#include <cjson/cJSON.h>
+int main(void) {
+cJSON *_n0 = cJSON_CreateArray();
+cJSON *_n1 = cJSON_CreateBool(1);
+cJSON_AddItemToArray(_n0, _n1);
+cJSON *_n2 = cJSON_CreateBool(0);
+cJSON_AddItemToArray(_n0, _n2);
+cJSON *_n3 = cJSON_CreateBool(1);
+cJSON_AddItemToArray(_n0, _n3);
+cJSON *my_data = _n0;
+    (void)my_data;
+    return 0;
+}

--- a/tests/integration/cases/call_scalar_args/C_json_type_cjson_call@c99.c
+++ b/tests/integration/cases/call_scalar_args/C_json_type_cjson_call@c99.c
@@ -1,0 +1,8 @@
+#include <cjson/cJSON.h>
+static void process(CVal _a0) { (void)_a0; }
+int main(void) {
+process(((CVal){.s = "hello"}));
+process(((CVal){.i = 42}));
+process(((CVal){.b = true}));
+    return 0;
+}

--- a/tests/integration/cases/call_scalar_args/C_json_type_cjson_call@c99.c
+++ b/tests/integration/cases/call_scalar_args/C_json_type_cjson_call@c99.c
@@ -1,8 +1,8 @@
 #include <cjson/cJSON.h>
-static void process(CVal _a0) { (void)_a0; }
+static void process(cJSON *_a0) { (void)_a0; }
 int main(void) {
-process(((CVal){.s = "hello"}));
-process(((CVal){.i = 42}));
-process(((CVal){.b = true}));
+process(cJSON_CreateString("hello"));
+process(cJSON_CreateNumber((double)42));
+process(cJSON_CreateBool(1));
     return 0;
 }

--- a/tests/integration/cases/date_set/C_json_type_cjson_date_set@c99.c
+++ b/tests/integration/cases/date_set/C_json_type_cjson_date_set@c99.c
@@ -1,0 +1,11 @@
+#include <cjson/cJSON.h>
+int main(void) {
+cJSON *_n0 = cJSON_CreateArray();
+cJSON *_n1 = cJSON_CreateString("2024-01-15");
+cJSON_AddItemToArray(_n0, _n1);
+cJSON *_n2 = cJSON_CreateString("2024-06-01");
+cJSON_AddItemToArray(_n0, _n2);
+cJSON *my_data = _n0;
+    (void)my_data;
+    return 0;
+}

--- a/tests/integration/cases/dates/C_json_type_cjson_dates@c99.c
+++ b/tests/integration/cases/dates/C_json_type_cjson_dates@c99.c
@@ -1,0 +1,11 @@
+#include <cjson/cJSON.h>
+int main(void) {
+cJSON *_n0 = cJSON_CreateObject();
+cJSON *_n1 = cJSON_CreateString("2024-01-15");
+cJSON_AddItemToObject(_n0, "date", _n1);
+cJSON *_n2 = cJSON_CreateString("2024-01-15T12:30:00+00:00");
+cJSON_AddItemToObject(_n0, "datetime", _n2);
+cJSON *my_data = _n0;
+    (void)my_data;
+    return 0;
+}

--- a/tests/integration/cases/dict_with_list_value/C_json_type_cjson@c99.c
+++ b/tests/integration/cases/dict_with_list_value/C_json_type_cjson@c99.c
@@ -1,0 +1,17 @@
+#include <cjson/cJSON.h>
+int main(void) {
+cJSON *_n0 = cJSON_CreateObject();
+cJSON *_n1 = cJSON_CreateString("Alice");
+cJSON_AddItemToObject(_n0, "name", _n1);
+cJSON *_n2 = cJSON_CreateArray();
+cJSON *_n3 = cJSON_CreateNumber((double)10);
+cJSON_AddItemToArray(_n2, _n3);
+cJSON *_n4 = cJSON_CreateNumber((double)20);
+cJSON_AddItemToArray(_n2, _n4);
+cJSON *_n5 = cJSON_CreateNumber((double)30);
+cJSON_AddItemToArray(_n2, _n5);
+cJSON_AddItemToObject(_n0, "scores", _n2);
+cJSON *my_data = _n0;
+    (void)my_data;
+    return 0;
+}

--- a/tests/integration/cases/dict_with_list_value/C_json_type_cjson_combined@c99.c
+++ b/tests/integration/cases/dict_with_list_value/C_json_type_cjson_combined@c99.c
@@ -1,0 +1,30 @@
+#include <cjson/cJSON.h>
+int main(void) {
+cJSON *_n0 = cJSON_CreateObject();
+cJSON *_n1 = cJSON_CreateString("Alice");
+cJSON_AddItemToObject(_n0, "name", _n1);
+cJSON *_n2 = cJSON_CreateArray();
+cJSON *_n3 = cJSON_CreateNumber((double)10);
+cJSON_AddItemToArray(_n2, _n3);
+cJSON *_n4 = cJSON_CreateNumber((double)20);
+cJSON_AddItemToArray(_n2, _n4);
+cJSON *_n5 = cJSON_CreateNumber((double)30);
+cJSON_AddItemToArray(_n2, _n5);
+cJSON_AddItemToObject(_n0, "scores", _n2);
+cJSON *my_data = _n0;
+(void)my_data;
+cJSON *_m0 = cJSON_CreateObject();
+cJSON *_m1 = cJSON_CreateString("Alice");
+cJSON_AddItemToObject(_m0, "name", _m1);
+cJSON *_m2 = cJSON_CreateArray();
+cJSON *_m3 = cJSON_CreateNumber((double)10);
+cJSON_AddItemToArray(_m2, _m3);
+cJSON *_m4 = cJSON_CreateNumber((double)20);
+cJSON_AddItemToArray(_m2, _m4);
+cJSON *_m5 = cJSON_CreateNumber((double)30);
+cJSON_AddItemToArray(_m2, _m5);
+cJSON_AddItemToObject(_m0, "scores", _m2);
+my_data = _m0;
+    (void)my_data;
+    return 0;
+}

--- a/tests/integration/cases/dict_with_nulls/C_json_type_cjson_nulls@c99.c
+++ b/tests/integration/cases/dict_with_nulls/C_json_type_cjson_nulls@c99.c
@@ -1,0 +1,13 @@
+#include <cjson/cJSON.h>
+int main(void) {
+cJSON *_n0 = cJSON_CreateObject();
+cJSON *_n1 = cJSON_CreateString("Alice");
+cJSON_AddItemToObject(_n0, "name", _n1);
+cJSON *_n2 = cJSON_CreateNull();
+cJSON_AddItemToObject(_n0, "score", _n2);
+cJSON *_n3 = cJSON_CreateNumber((double)30);
+cJSON_AddItemToObject(_n0, "age", _n3);
+cJSON *my_data = _n0;
+    (void)my_data;
+    return 0;
+}

--- a/tests/integration/cases/nested_mixed_inner/C_json_type_cjson_nested_mixed@c99.c
+++ b/tests/integration/cases/nested_mixed_inner/C_json_type_cjson_nested_mixed@c99.c
@@ -1,0 +1,19 @@
+#include <cjson/cJSON.h>
+int main(void) {
+cJSON *_n0 = cJSON_CreateArray();
+cJSON *_n1 = cJSON_CreateArray();
+cJSON *_n2 = cJSON_CreateNumber((double)1);
+cJSON_AddItemToArray(_n1, _n2);
+cJSON *_n3 = cJSON_CreateString("a");
+cJSON_AddItemToArray(_n1, _n3);
+cJSON_AddItemToArray(_n0, _n1);
+cJSON *_n4 = cJSON_CreateArray();
+cJSON *_n5 = cJSON_CreateNumber((double)2);
+cJSON_AddItemToArray(_n4, _n5);
+cJSON *_n6 = cJSON_CreateString("b");
+cJSON_AddItemToArray(_n4, _n6);
+cJSON_AddItemToArray(_n0, _n4);
+cJSON *my_data = _n0;
+    (void)my_data;
+    return 0;
+}

--- a/tests/integration/cases/ordered_map/C_json_type_cjson_ordered_map@c99.c
+++ b/tests/integration/cases/ordered_map/C_json_type_cjson_ordered_map@c99.c
@@ -1,0 +1,13 @@
+#include <cjson/cJSON.h>
+int main(void) {
+cJSON *_n0 = cJSON_CreateObject();
+cJSON *_n1 = cJSON_CreateString("Alice");
+cJSON_AddItemToObject(_n0, "name", _n1);
+cJSON *_n2 = cJSON_CreateNumber((double)30);
+cJSON_AddItemToObject(_n0, "age", _n2);
+cJSON *_n3 = cJSON_CreateBool(1);
+cJSON_AddItemToObject(_n0, "active", _n3);
+cJSON *my_data = _n0;
+    (void)my_data;
+    return 0;
+}

--- a/tests/integration/cases/scalar_datetime_naive/C_json_type_cjson_datetime_naive@c99.c
+++ b/tests/integration/cases/scalar_datetime_naive/C_json_type_cjson_datetime_naive@c99.c
@@ -1,0 +1,7 @@
+#include <cjson/cJSON.h>
+int main(void) {
+cJSON *_n0 = cJSON_CreateString("2024-01-15T12:30:00");
+cJSON *my_data = _n0;
+    (void)my_data;
+    return 0;
+}

--- a/tests/integration/cases/scalar_float/C_json_type_cjson_float@c99.c
+++ b/tests/integration/cases/scalar_float/C_json_type_cjson_float@c99.c
@@ -1,0 +1,7 @@
+#include <cjson/cJSON.h>
+int main(void) {
+cJSON *_n0 = cJSON_CreateNumber(3.14);
+cJSON *my_data = _n0;
+    (void)my_data;
+    return 0;
+}

--- a/tests/integration/cases/scalar_int_large/C_json_type_cjson_long@c99.c
+++ b/tests/integration/cases/scalar_int_large/C_json_type_cjson_long@c99.c
@@ -1,0 +1,7 @@
+#include <cjson/cJSON.h>
+int main(void) {
+cJSON *_n0 = cJSON_CreateNumber((double)2147483648);
+cJSON *my_data = _n0;
+    (void)my_data;
+    return 0;
+}

--- a/tests/integration/cases/scalar_int_very_large/C_json_type_cjson_bigint@c99.c
+++ b/tests/integration/cases/scalar_int_very_large/C_json_type_cjson_bigint@c99.c
@@ -1,0 +1,7 @@
+#include <cjson/cJSON.h>
+int main(void) {
+cJSON *_n0 = cJSON_CreateNumber((double)9223372036854775808ULL);
+cJSON *my_data = _n0;
+    (void)my_data;
+    return 0;
+}

--- a/tests/integration/cases/scalar_time/C_json_type_cjson_time@c99.c
+++ b/tests/integration/cases/scalar_time/C_json_type_cjson_time@c99.c
@@ -1,0 +1,9 @@
+#include <cjson/cJSON.h>
+int main(void) {
+cJSON *_n0 = cJSON_CreateObject();
+cJSON *_n1 = cJSON_CreateString("09:30:00");
+cJSON_AddItemToObject(_n0, "starts_at", _n1);
+cJSON *my_data = _n0;
+    (void)my_data;
+    return 0;
+}

--- a/tests/integration/variant_cases.py
+++ b/tests/integration/variant_cases.py
@@ -575,6 +575,15 @@ def build_json_type_variants() -> Iterable[Variant]:
             collection_layout=literalizer.CollectionLayout.COMPACT,
         ),
         Variant(
+            name="C_json_type_cjson",
+            spec=make_spec(
+                lang_cls=C,
+                json_type=C.json_types.CJSON,
+            ),
+            lang_cls=C,
+            collection_layout=literalizer.CollectionLayout.COMPACT,
+        ),
+        Variant(
             name="FSharp_json_type_json_node",
             spec=make_spec(
                 lang_cls=FSharp,
@@ -2632,6 +2641,20 @@ def build_variant_cases() -> list[VariantCase]:
                         json_type=Cpp.json_types.NLOHMANN_JSON,
                     ),
                     lang_cls=Cpp,
+                    collection_layout=literalizer.CollectionLayout.COMPACT,
+                ),
+                case_dir_name="dict_with_list_value",
+                variable_form=literalizer.BothVariableForms(name="my_data"),
+            ),
+            VariantCase(
+                variant_name="C_json_type_cjson_combined",
+                variant=Variant(
+                    name="C_json_type_cjson_combined",
+                    spec=make_spec(
+                        lang_cls=C,
+                        json_type=C.json_types.CJSON,
+                    ),
+                    lang_cls=C,
                     collection_layout=literalizer.CollectionLayout.COMPACT,
                 ),
                 case_dir_name="dict_with_list_value",


### PR DESCRIPTION
## Summary

- Add ``C(json_type=CJSON)`` rendering JSON values as a cJSON tree built with ``cJSON_Create*`` / ``cJSON_AddItemTo*`` calls.
- Container construction is multi-statement (build statements in ``body_preamble``, binding ``cJSON *NAME = _n0;``), portable standard C99 — see #2766 for the design discussion of why option-2 over GCC statement-expressions or helper macros.
- ``RECORD`` heterogeneous strategy rejected under CJSON in the first slice (will reuse the existing CVal/CKV path).
- ``lint-c-tidy`` installs ``libcjson-dev`` so the cJSON header is on the default include path.
- Round-trip script rewrite is the sibling sub-issue #2767 and not in this PR.

Closes #2766.

## Test plan

- [x] ``uv run --extra dev pytest`` (5380 passed, 30519 subtests passed)
- [x] ``uv run --extra dev mypy src/literalizer/languages/c.py``
- [x] ``uv run --extra dev pyright src/literalizer/languages/c.py``
- [x] ``uv run pre-commit run --hook-stage manual pylint`` on the changed files
- [x] Pre-push hooks (mypy, pyright, ty, pyrefly) all passed
- [ ] CI: ``lint-c-tidy`` compiles each new ``C_json_type_cjson*@c99.c`` golden against the installed ``libcjson-dev`` header

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to optional C json_type output and CI dependencies; default CVal generation is unchanged when json_type is unset.
> 
> **Overview**
> Adds **`C(json_type=CJSON)`**, a new C output mode that builds JSON values with the **cJSON** library instead of the tagged **`CVal`** union.
> 
> When this mode is active, generated code uses **`#include <cjson/cJSON.h>`**, emits multi-statement trees via **`cJSON_Create*`** and **`cJSON_AddItemToObject` / `cJSON_AddItemToArray`**, and binds roots as **`cJSON *`** (with **`_n*`** / **`_m*`** temporaries so declaration and reassignment in one function do not collide). Call sites get **`cJSON *`** stubs and **`cJSON_Create*`** arguments. **`heterogeneous_strategy=RECORD`** is rejected at spec time via **`IncompatibleFormatsError`**.
> 
> CI installs **`libcjson-dev`** earlier in **`lint-fast`** (before **Lint C**, with **`-lcjson`**), and adds the same package to **`lint-c-tidy`** so headers parse. Integration goldens and a **`C_json_type_cjson`** variant (plus a combined reassignment case) exercise the new path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 301c3088501dc267d48ee99a15b6378b4afa5657. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->