### PR TITLE
Add Scheme json_type=GUILE_JSON option (#2760)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -464,11 +464,15 @@ jobs:
       # Invoke ``guile-3.0`` directly rather than ``guile`` because
       # cache-apt-pkgs-action does not replay the package's
       # ``update-alternatives`` postinst on cache hit, so ``/usr/bin/guile``
-      # is missing.
+      # is missing.  ``-L $LITERALIZER_GUILE_JSON_PATH`` puts the
+      # ``Install guile-json`` checkout on Guile's load path so fixtures
+      # that ``(use-modules (json))`` (the ``Scheme_json_type_guile_json``
+      # variant,  # 2760) resolve there; ``--no-auto-compile`` keeps the
+      # run from writing a ``.go`` cache for it.
       - name: Lint Scheme
         run: |-
           find tests/integration/cases -name '*.scm' -print0 > /tmp/files-scheme && test -s /tmp/files-scheme
-          xargs -0 -P "$(nproc)" -I{} guile-3.0 --no-auto-compile -s {} < /tmp/files-scheme
+          xargs -0 -P "$(nproc)" -I{} guile-3.0 --no-auto-compile -L "$LITERALIZER_GUILE_JSON_PATH" -s {} < /tmp/files-scheme
 
       # Basic JSON -> Scheme -> JSON round-trip (issue 1867). Runs here
       # because this is the job with the `guile-3.0` toolchain on PATH;

--- a/docs/source/languages.rst
+++ b/docs/source/languages.rst
@@ -511,7 +511,7 @@ Scheme exposes the same option through
 
 .. code-block:: python
 
-   """Render Scheme data for guile-json's ``scm->json``."""
+   """Render Scheme data for the ``scm->json`` writer in guile-json."""
 
    from literalizer import InputFormat, NewVariable, literalize
    from literalizer.languages import Scheme

--- a/docs/source/languages.rst
+++ b/docs/source/languages.rst
@@ -506,6 +506,38 @@ must be strings so they remain valid JSON object keys, and special
 floats (``NaN``, ``+Infinity``, ``-Infinity``) are rejected because
 JSON has no syntax for them.
 
+Scheme exposes the same option through
+``Scheme.json_types.GUILE_JSON``:
+
+.. code-block:: python
+
+   """Render Scheme data for guile-json's ``scm->json``."""
+
+   from literalizer import InputFormat, NewVariable, literalize
+   from literalizer.languages import Scheme
+
+   result = literalize(
+       source='{"id": 1, "tags": ["red", 2]}',
+       input_format=InputFormat.JSON,
+       language=Scheme(
+           json_type=Scheme.json_types.GUILE_JSON,
+       ),
+       variable_form=NewVariable(name="my-data"),
+   )
+
+This renders objects as Scheme association lists
+(``(list (cons "k" v) ...)``), arrays
+as vectors (``(vector v ...)``), and null as the symbol ``'null`` so
+the binding can be handed directly to ``(scm->json my-data)`` from the
+guile-json ``(json)`` module without an intermediate shape walker.
+The default Scheme rendering folds both objects and arrays into a
+flat ``(list ...)`` form, which makes ``{}`` indistinguishable from
+``[]`` and ``{"a": 1}`` indistinguishable from ``["a", 1]``; the
+``GUILE_JSON`` mode resolves that ambiguity at the source.  Dict keys
+must be strings so they remain valid JSON object keys, and special
+floats (``NaN``, ``+inf.0``, ``-inf.0``) are rejected because JSON
+has no syntax for them.
+
 Erlang exposes the same option through
 ``Erlang.json_types.OTP_JSON``:
 

--- a/newsfragments/2760.change
+++ b/newsfragments/2760.change
@@ -1,0 +1,1 @@
+Add a ``json_type=Scheme.json_types.GUILE_JSON`` option to the Scheme language that renders objects as Scheme association lists, arrays as vectors, and null as ``'null`` so the literalized binding can be handed directly to guile-json's ``scm->json`` without an intermediate shape walker.

--- a/src/literalizer/languages/scheme.py
+++ b/src/literalizer/languages/scheme.py
@@ -3,6 +3,7 @@
 import dataclasses
 import datetime
 import enum
+import math
 from collections.abc import Callable, Sequence
 from functools import cached_property
 from typing import ClassVar
@@ -20,6 +21,7 @@ from literalizer._formatters.format_dates import (
 )
 from literalizer._formatters.format_entries import (
     dict_entry_with_separator,
+    dict_entry_with_template,
     format_bytes_base64,
     format_bytes_hex,
     passthrough_sequence_entry,
@@ -73,12 +75,50 @@ from literalizer._language import (
     no_leading_preamble,
     no_type_hint_preamble,
     no_validate_call_arg,
-    no_validate_spec_for_data,
     wrap_combined_in_file_noop,
     wrap_in_file_noop,
 )
-from literalizer._types import Value
-from literalizer.exceptions import CallArgNotSupportedError
+from literalizer._types import OrderedMap, Value
+from literalizer.exceptions import (
+    CallArgNotSupportedError,
+    UnrepresentableInputError,
+    UnrepresentableSpecialFloatError,
+)
+
+# Format definitions used while ``json_type=GUILE_JSON`` is active.
+# Objects are emitted as association lists
+# (``(list (cons "k" v) ...)``) because guile-json's ``json-valid?``
+# accepts only that form, not hash tables (see
+# ``json/builder.scm:188`` upstream; matches the round-trip helper's
+# existing ``normalize`` walker).  Arrays become vectors
+# (``(vector v ...)``) since guile-json's ``scm->json`` distinguishes
+# vector arrays from list-of-pairs objects.  Sets reuse the array
+# (vector) form because JSON has no set type.
+_GUILE_JSON_SEQUENCE_CONFIG = SequenceFormatConfig(
+    sequence_open=fixed_open(open_str="(vector "),
+    close=")",
+    supports_heterogeneity=True,
+    single_element_trailing_comma=False,
+    supports_trailing_comma=False,
+    empty_sequence="(vector)",
+    preamble_lines=(),
+    format_entry=passthrough_sequence_entry,
+    typed_opener_fallback=None,
+    uses_typed_literal_for_scalars=False,
+    requires_uniform_record_shapes=False,
+    declared_type=None,
+    narrowed_empty_form=None,
+)
+
+_GUILE_JSON_SET_CONFIG = SetFormatConfig(
+    set_open=fixed_open(open_str="(vector "),
+    close=")",
+    empty_set="(vector)",
+    preamble_lines=(),
+    set_opener_template="",
+    supports_heterogeneity=True,
+    supports_trailing_comma=False,
+)
 
 
 @beartype
@@ -364,7 +404,14 @@ class Scheme(metaclass=LanguageCls):
     heterogeneous_strategies = HeterogeneousStrategies
 
     class JsonTypes(enum.Enum):
-        """Empty: this language has no JSON value-type variants."""
+        """JSON value type options for Scheme."""
+
+        GUILE_JSON = "guile-json scm->json value shape"
+        """Guile-json's ``scm->json`` value shape: Scheme association
+        lists for objects, vectors for arrays, ``'null`` for JSON
+        null.  The literalized output can be handed directly to
+        ``(scm->json ...)`` without a runtime shape walker.
+        """
 
     json_types = JsonTypes
 
@@ -385,8 +432,6 @@ class Scheme(metaclass=LanguageCls):
         IdentifierCase.KEBAB,
     )
     supported_ref_cases: ClassVar[frozenset[IdentifierCase]] = ALL_REF_CASES
-
-    validate_spec_for_data = no_validate_spec_for_data
 
     @cached_property
     def validate_call_arg(self) -> Callable[[Value], None]:
@@ -456,6 +501,7 @@ class Scheme(metaclass=LanguageCls):
     heterogeneous_strategy: HeterogeneousStrategies = (
         HeterogeneousStrategies.ERROR
     )
+    json_type: JsonTypes | None = None
     call_style: CallStyles = CallStyles.PREFIX
     # The `Install apt packages` step in `.github/workflows/lint.yml`
     # installs the `guile-3.0` apt package, whose Guile 3.x implements
@@ -465,7 +511,6 @@ class Scheme(metaclass=LanguageCls):
     language_version: VersionFormats = VersionFormats.R7RS
     indent: str = "    "
 
-    null_literal: ClassVar[str] = "'()"
     true_literal: ClassVar[str] = "#t"
     false_literal: ClassVar[str] = "#f"
     indent_closing_delimiter: ClassVar[bool] = False
@@ -475,9 +520,80 @@ class Scheme(metaclass=LanguageCls):
     supports_scalar_before_comments: ClassVar[bool] = True
     supports_scalar_inline_comments: ClassVar[bool] = False
     statement_terminator: ClassVar[str] = ""
-    static_preamble: ClassVar[Sequence[str]] = ()
     static_body_preamble: ClassVar[Sequence[str]] = ()
     special_float_preamble: ClassVar[tuple[str, ...]] = ()
+
+    @cached_property
+    def _json_type_active(self) -> bool:
+        """Return whether ``json_type=GUILE_JSON`` is selected."""
+        return self.json_type is not None
+
+    @cached_property
+    def null_literal(self) -> str:
+        """The literal representing null.
+
+        Under :attr:`json_type` the value must be the null sentinel
+        that guile-json recognizes (the symbol ``'null``, matching
+        the default of its ``*null*`` parameter); the flat-list mode
+        uses the empty list, which is conventional for ``null`` in
+        Scheme.
+        """
+        return "'null" if self._json_type_active else "'()"
+
+    @cached_property
+    def static_preamble(self) -> Sequence[str]:
+        """File-scope preamble.
+
+        Under :attr:`json_type` the rendered value is a tree of
+        Scheme association lists and vectors that
+        ``(scm->json ...)`` accepts directly, so the ``(json)``
+        module must be imported.
+        """
+        if self._json_type_active:
+            return ("(use-modules (json))",)
+        return ()
+
+    def validate_spec_for_data(self, data: Value) -> None:
+        """Reject data that ``json_type=GUILE_JSON`` cannot represent.
+
+        Walks *data* under :attr:`json_type` to reject non-string dict
+        keys (JSON objects keys must be strings) and the special
+        floats ``NaN`` / ``+inf.0`` / ``-inf.0`` (not valid JSON).
+        """
+        if self._json_type_active:
+            self._validate_guile_json_value(data)
+
+    def _validate_guile_json_value(self, data: Value, /) -> None:
+        """Recursively validate that *data* is JSON-representable."""
+        match data:
+            case OrderedMap() | dict():
+                for key, value in data.items():
+                    if not isinstance(key, str):
+                        msg = (
+                            "Scheme json_type=GUILE_JSON can only "
+                            "represent dict keys as JSON object "
+                            f"strings, not {type(key).__name__}"
+                        )
+                        raise UnrepresentableInputError(msg)
+                    self._validate_guile_json_value(value)
+            case list() | set():
+                for item in data:
+                    self._validate_guile_json_value(item)
+            case float():
+                self._validate_guile_json_float(value=data)
+            case _:
+                return
+
+    @staticmethod
+    def _validate_guile_json_float(*, value: float) -> None:
+        """Reject ``NaN`` / ``+inf.0`` / ``-inf.0`` floats."""
+        if math.isnan(value) or math.isinf(value):
+            msg = (
+                "Scheme json_type=GUILE_JSON cannot represent the "
+                f"special float {value!r}: JSON has no NaN or "
+                "infinity."
+            )
+            raise UnrepresentableSpecialFloatError(msg)
 
     @cached_property
     def call_style_config(self) -> CallStyle:
@@ -622,22 +738,56 @@ class Scheme(metaclass=LanguageCls):
 
     @cached_property
     def sequence_format_config(self) -> SequenceFormatConfig:
-        """Configuration for the chosen sequence format."""
+        """Configuration for the chosen sequence format.
+
+        Under :attr:`json_type` arrays are emitted as ``(vector ...)``
+        so ``scm->json`` round-trips them as JSON arrays unambiguously.
+        """
+        if self._json_type_active:
+            return _GUILE_JSON_SEQUENCE_CONFIG
         return self.sequence_format.value
 
     @cached_property
     def set_format_config(self) -> SetFormatConfig:
-        """Configuration for the chosen set format."""
+        """Configuration for the chosen set format.
+
+        Under :attr:`json_type` sets share the array form
+        (``(vector ...)``); JSON has no native set type.
+        """
+        if self._json_type_active:
+            return _GUILE_JSON_SET_CONFIG
         return self.set_format.value
 
     @cached_property
     def sequence_open(self) -> Callable[[list[Value]], str]:
         """Callable that returns the opening delimiter for a sequence."""
+        if self._json_type_active:
+            return _GUILE_JSON_SEQUENCE_CONFIG.sequence_open
         return self.sequence_format.value.sequence_open
 
     @cached_property
     def dict_format_config(self) -> DictFormatConfig:
-        """Configuration for dict formatting."""
+        """Configuration for dict formatting.
+
+        Under :attr:`json_type` each entry is a ``(cons "k" v)`` pair
+        and the dict wraps them in ``(list ...)`` to form a Scheme
+        association list; ``scm->json``'s ``json-valid?`` accepts only
+        that shape for JSON objects.  The default mode emits the
+        legacy flat ``(list "k" v "k" v ...)`` form.
+        """
+        if self._json_type_active:
+            return DictFormatConfig(
+                dict_open=fixed_open(open_str="(list "),
+                close=")",
+                format_entry=dict_entry_with_template(
+                    template="(cons {key} {value})",
+                    format_value=passthrough_sequence_entry,
+                ),
+                empty_dict="(list)",
+                preamble_lines=(),
+                narrowed_open=None,
+                supports_trailing_comma=True,
+            )
         return DictFormatConfig(
             dict_open=fixed_open(open_str="(list "),
             close=")",
@@ -688,7 +838,13 @@ class Scheme(metaclass=LanguageCls):
 
     @cached_property
     def ordered_map_format_config(self) -> OrderedMapFormatConfig:
-        """Configuration for ordered-map formatting."""
+        """Configuration for ordered-map formatting.
+
+        Under :attr:`json_type` an ordered map is rendered as the same
+        association-list shape used for plain dicts so ``scm->json``
+        round-trips it as a JSON object (key order is preserved by
+        the surrounding list's element order).
+        """
         return OrderedMapFormatConfig(
             ordered_map_open=fixed_open(open_str="(list "),
             close=")",
@@ -697,7 +853,16 @@ class Scheme(metaclass=LanguageCls):
 
     @cached_property
     def format_ordered_map_entry(self) -> Callable[[str, Value, str], str]:
-        """Callable that formats one ordered-map entry."""
+        """Callable that formats one ordered-map entry.
+
+        Under :attr:`json_type` each entry is a ``(cons "k" v)`` pair
+        matching :attr:`dict_format_config`.
+        """
+        if self._json_type_active:
+            return dict_entry_with_template(
+                template="(cons {key} {value})",
+                format_value=passthrough_sequence_entry,
+            )
         return dict_entry_with_separator(
             separator=" ",
             format_value=passthrough_sequence_entry,

--- a/src/literalizer/languages/scheme.py
+++ b/src/literalizer/languages/scheme.py
@@ -87,13 +87,13 @@ from literalizer.exceptions import (
 
 # Format definitions used while ``json_type=GUILE_JSON`` is active.
 # Objects are emitted as association lists
-# (``(list (cons "k" v) ...)``) because guile-json's ``json-valid?``
-# accepts only that form, not hash tables (see
+# (``(list (cons "k" v) ...)``) because the ``json-valid?`` predicate
+# in guile-json accepts only that form, not hash tables (see
 # ``json/builder.scm:188`` upstream; matches the round-trip helper's
 # existing ``normalize`` walker).  Arrays become vectors
-# (``(vector v ...)``) since guile-json's ``scm->json`` distinguishes
-# vector arrays from list-of-pairs objects.  Sets reuse the array
-# (vector) form because JSON has no set type.
+# (``(vector v ...)``) since the ``scm->json`` writer in guile-json
+# distinguishes vector arrays from list-of-pairs objects.  Sets
+# reuse the array (vector) form because JSON has no set type.
 _GUILE_JSON_SEQUENCE_CONFIG = SequenceFormatConfig(
     sequence_open=fixed_open(open_str="(vector "),
     close=")",

--- a/tests/errors/test_scheme_json_type_errors.py
+++ b/tests/errors/test_scheme_json_type_errors.py
@@ -1,0 +1,58 @@
+"""Scheme ``json_type`` rejection paths."""
+
+import pytest
+
+from literalizer import InputFormat, NewVariable, literalize
+from literalizer.exceptions import (
+    UnrepresentableInputError,
+    UnrepresentableSpecialFloatError,
+)
+from literalizer.languages import Scheme
+
+
+def test_scheme_json_type_rejects_non_string_dict_keys() -> None:
+    """``scm->json`` object keys must be strings."""
+    with pytest.raises(
+        expected_exception=UnrepresentableInputError,
+        match="dict keys as JSON object",
+    ):
+        literalize(
+            source="{1: one}",
+            input_format=InputFormat.YAML,
+            language=Scheme(
+                json_type=Scheme.json_types.GUILE_JSON,
+            ),
+            variable_form=NewVariable(name="my-data"),
+        )
+
+
+def test_scheme_json_type_rejects_special_float_nan() -> None:
+    """Reject ``NaN`` since JSON has no syntax for it."""
+    with pytest.raises(
+        expected_exception=UnrepresentableSpecialFloatError,
+        match="NaN or infinity",
+    ):
+        literalize(
+            source="[NaN]",
+            input_format=InputFormat.JSON5,
+            language=Scheme(
+                json_type=Scheme.json_types.GUILE_JSON,
+            ),
+            variable_form=NewVariable(name="my-data"),
+        )
+
+
+def test_scheme_json_type_rejects_special_float_infinity() -> None:
+    """Reject ``Infinity`` since JSON has no syntax for it."""
+    with pytest.raises(
+        expected_exception=UnrepresentableSpecialFloatError,
+        match="NaN or infinity",
+    ):
+        literalize(
+            source="[Infinity]",
+            input_format=InputFormat.JSON5,
+            language=Scheme(
+                json_type=Scheme.json_types.GUILE_JSON,
+            ),
+            variable_form=NewVariable(name="my-data"),
+        )

--- a/tests/integration/cases/binary/Scheme_json_type_guile_json_binary@r7rs.scm
+++ b/tests/integration/cases/binary/Scheme_json_type_guile_json_binary@r7rs.scm
@@ -1,0 +1,4 @@
+(use-modules (json))
+(define my_data (vector
+    "48656c6c6f"
+))

--- a/tests/integration/cases/bool_list/Scheme_json_type_guile_json_bool_list@r7rs.scm
+++ b/tests/integration/cases/bool_list/Scheme_json_type_guile_json_bool_list@r7rs.scm
@@ -1,0 +1,6 @@
+(use-modules (json))
+(define my_data (vector
+    #t
+    #f
+    #t
+))

--- a/tests/integration/cases/call_scalar_args/Scheme_json_type_guile_json_call@r7rs.scm
+++ b/tests/integration/cases/call_scalar_args/Scheme_json_type_guile_json_call@r7rs.scm
@@ -1,0 +1,5 @@
+(use-modules (json))
+(define process (lambda args (if #f #f)))
+(process "hello")
+(process 42)
+(process #t)

--- a/tests/integration/cases/date_set/Scheme_json_type_guile_json_date_set@r7rs.scm
+++ b/tests/integration/cases/date_set/Scheme_json_type_guile_json_date_set@r7rs.scm
@@ -1,0 +1,5 @@
+(use-modules (json))
+(define my_data (vector
+    "2024-01-15"
+    "2024-06-01"
+))

--- a/tests/integration/cases/dates/Scheme_json_type_guile_json_dates@r7rs.scm
+++ b/tests/integration/cases/dates/Scheme_json_type_guile_json_dates@r7rs.scm
@@ -1,0 +1,5 @@
+(use-modules (json))
+(define my_data (list
+    (cons "date" "2024-01-15")
+    (cons "datetime" "2024-01-15T12:30:00+00:00")
+))

--- a/tests/integration/cases/dict_with_list_value/Scheme_json_type_guile_json@r7rs.scm
+++ b/tests/integration/cases/dict_with_list_value/Scheme_json_type_guile_json@r7rs.scm
@@ -1,0 +1,5 @@
+(use-modules (json))
+(define my_data (list
+    (cons "name" "Alice")
+    (cons "scores" (vector 10 20 30))
+))

--- a/tests/integration/cases/dict_with_nulls/Scheme_json_type_guile_json_nulls@r7rs.scm
+++ b/tests/integration/cases/dict_with_nulls/Scheme_json_type_guile_json_nulls@r7rs.scm
@@ -1,0 +1,6 @@
+(use-modules (json))
+(define my_data (list
+    (cons "name" "Alice")
+    (cons "score" 'null)
+    (cons "age" 30)
+))

--- a/tests/integration/cases/nested_mixed_inner/Scheme_json_type_guile_json_nested_mixed@r7rs.scm
+++ b/tests/integration/cases/nested_mixed_inner/Scheme_json_type_guile_json_nested_mixed@r7rs.scm
@@ -1,0 +1,5 @@
+(use-modules (json))
+(define my_data (vector
+    (vector 1 "a")
+    (vector 2 "b")
+))

--- a/tests/integration/cases/ordered_map/Scheme_json_type_guile_json_ordered_map@r7rs.scm
+++ b/tests/integration/cases/ordered_map/Scheme_json_type_guile_json_ordered_map@r7rs.scm
@@ -1,0 +1,6 @@
+(use-modules (json))
+(define my_data (list
+    (cons "name" "Alice")
+    (cons "age" 30)
+    (cons "active" #t)
+))

--- a/tests/integration/cases/scalar_datetime_naive/Scheme_json_type_guile_json_datetime_naive@r7rs.scm
+++ b/tests/integration/cases/scalar_datetime_naive/Scheme_json_type_guile_json_datetime_naive@r7rs.scm
@@ -1,0 +1,2 @@
+(use-modules (json))
+(define my_data "2024-01-15T12:30:00")

--- a/tests/integration/cases/scalar_float/Scheme_json_type_guile_json_float@r7rs.scm
+++ b/tests/integration/cases/scalar_float/Scheme_json_type_guile_json_float@r7rs.scm
@@ -1,0 +1,2 @@
+(use-modules (json))
+(define my_data 3.14)

--- a/tests/integration/cases/scalar_int_large/Scheme_json_type_guile_json_long@r7rs.scm
+++ b/tests/integration/cases/scalar_int_large/Scheme_json_type_guile_json_long@r7rs.scm
@@ -1,0 +1,2 @@
+(use-modules (json))
+(define my_data 2147483648)

--- a/tests/integration/cases/scalar_int_very_large/Scheme_json_type_guile_json_bigint@r7rs.scm
+++ b/tests/integration/cases/scalar_int_very_large/Scheme_json_type_guile_json_bigint@r7rs.scm
@@ -1,0 +1,2 @@
+(use-modules (json))
+(define my_data 9223372036854775808)

--- a/tests/integration/cases/scalar_time/Scheme_json_type_guile_json_time@r7rs.scm
+++ b/tests/integration/cases/scalar_time/Scheme_json_type_guile_json_time@r7rs.scm
@@ -1,0 +1,4 @@
+(use-modules (json))
+(define my_data (list
+    (cons "starts_at" "09:30:00")
+))

--- a/tests/integration/variant_cases.py
+++ b/tests/integration/variant_cases.py
@@ -44,6 +44,7 @@ from literalizer.languages import (
     Roc,
     Rust,
     Scala,
+    Scheme,
     Swift,
     VisualBasic,
     Zig,
@@ -617,6 +618,15 @@ def build_json_type_variants() -> Iterable[Variant]:
                 json_type=PureScript.json_types.ARGONAUT_JSON,
             ),
             lang_cls=PureScript,
+            collection_layout=literalizer.CollectionLayout.COMPACT,
+        ),
+        Variant(
+            name="Scheme_json_type_guile_json",
+            spec=make_spec(
+                lang_cls=Scheme,
+                json_type=Scheme.json_types.GUILE_JSON,
+            ),
+            lang_cls=Scheme,
             collection_layout=literalizer.CollectionLayout.COMPACT,
         ),
         Variant(


### PR DESCRIPTION
## Summary

- New ``Scheme(json_type=Scheme.json_types.GUILE_JSON)`` mode that renders objects as Scheme association lists (``(list (cons "k" v) ...)``), arrays as vectors (``(vector ...)``), and null as the ``'null`` symbol, so the binding is accepted directly by guile-json's ``scm->json`` without the runtime shape walker the default flat-``(list ...)`` mode needs.
- Validates against non-string dict keys and ``NaN`` / ``±inf`` floats; injects ``(use-modules (json))`` into the static preamble; wires the variant into the cross-language golden corpus, the ``Lint Scheme`` CI step (passing ``-L $LITERALIZER_GUILE_JSON_PATH``), error tests, ``docs/source/languages.rst``, and ``newsfragments/2760.change``.
- Follow-up #2769 will rewire ``run_scheme_roundtrip.py`` onto this mode and drop the Python-emitted shape descriptor.

## Test plan

- [x] ``pytest`` (5383 passed, 30518 subtests passed)
- [x] 100% line+branch coverage on ``src/literalizer/languages/scheme.py``
- [x] Every generated ``.scm`` fixture compiled under ``guile`` + guile-json 4.7.3 locally and round-tripped through real ``scm->json-string``
- [x] Manual ``pylint`` and Sphinx ``spelling`` hooks pass

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Formatter and test/CI changes only; no auth, persistence, or runtime behavior outside Scheme literalization and Guile lint.
> 
> **Overview**
> Adds **`Scheme(json_type=Scheme.json_types.GUILE_JSON)`** so literalized data matches **guile-json**’s `scm->json` input: objects as **`(list (cons "k" v) ...)`**, arrays (and sets) as **`(vector ...)`**, JSON null as **`'null`**, plus a **`(use-modules (json))`** preamble. Default flat **`(list ...)`** output stays unchanged when the option is off.
> 
> **Validation** rejects non-string dict keys and **NaN / ±inf** floats. **CI** runs Guile with **`-L $LITERALIZER_GUILE_JSON_PATH`** so new `.scm` goldens load `(json)`. **Docs**, **newsfragment**, integration **variant** and **fixtures**, and **error tests** cover the mode.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b9bb5df30fd1dfafed9eb96bd0a7bf7fc280839f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->