### PR TITLE
Rewire run_scheme_roundtrip.py onto Scheme(json_type=GUILE_JSON)

### DIFF
--- a/.github/scripts/run_scheme_roundtrip.py
+++ b/.github/scripts/run_scheme_roundtrip.py
@@ -1,10 +1,10 @@
 """Scheme JSON round-trip check (issue #2677).
 
 Literalize the shared ``roundtrip_input.json`` document to a Scheme
-``(define my-data ...)`` binding, wrap it in a Guile script that
-normalizes the literalized value into the alist / vector tree
-``scm->json`` expects, run it under ``guile-3.0``, and hand the emitted
-JSON to :func:`roundtrip_common.verify`.
+``(define my-data ...)`` binding under
+``Scheme(json_type=Scheme.json_types.GUILE_JSON)``, wrap it in a Guile
+script, run it under ``guile-3.0``, and hand the emitted JSON to
+:func:`roundtrip_common.verify`.
 
 This lives here, driven by the ``Scheme roundtrip`` step of the
 ``lint-fast`` job in ``.github/workflows/lint.yml``, because that job
@@ -13,33 +13,19 @@ step clones the guile-json checkout that ``LITERALIZER_GUILE_JSON_PATH``
 points at.  It shares the same input and comparison logic as the other
 per-language round-trip helpers.
 
-The serializer is the ``(json)`` module from guile-json rather than a
-hand-rolled encoder (matching the preference expressed in the issue
-notes); Guile itself ships no JSON library.  The literalized Scheme
-output is shape-ambiguous: a dict becomes ``(list "k" v ...)`` and an
-array becomes ``(list v ...)``; both an empty dict and an empty array
-literalize to ``(list)``.  A purely runtime encoder therefore cannot
-tell ``{}`` from ``[]``.
-
-To avoid emitting one ``list-ref`` per leaf (as the Tcl / Common Lisp
-helpers do), Python instead emits a compact *shape tree* describing
-which subtrees of ``my-data`` are objects and which are arrays, plus a
-generic Scheme ``normalize`` walker that rebuilds the typed structure
-``scm->json`` accepts: an *alist* of ``(key . value)`` pairs for each
-object (``scm->json``'s ``json-valid?`` rejects hash tables, see
-``builder.scm:188``), and a vector for each array.  Shape nodes are
-``(obj (key . sub-shape) ...)``, ``(arr sub-shape ...)``, or the leaf
-symbol ``scalar``.  All JSON encoding -- string escaping, number
-formatting, separator placement -- is then done by a single
-``scm->json`` call, so no encoder details are hand-rolled.  No
-top-level keys are excluded: Guile has arbitrary-precision integers
-(so the 26-digit ``biginteger`` survives) and ``scm->json`` emits
-inexact reals via ``number->string``, which round-trips
-``1.7976931348623157e+308``; ``-0.0`` compares equal to ``0.0`` under
-the parsed-value diff in :func:`roundtrip_common.verify`.
+Under ``json_type=GUILE_JSON`` the literalized value is already the tree
+of association lists and vectors (with ``'null`` for JSON null) that
+guile-json's ``scm->json`` accepts directly, so the program emits a
+single ``(scm->json my-data)`` call.  All JSON encoding -- string
+escaping, number formatting, separator placement -- is done by that one
+call, so no encoder details are hand-rolled.  No top-level keys are
+excluded: Guile has arbitrary-precision integers (so the 26-digit
+``biginteger`` survives) and ``scm->json`` emits inexact reals via
+``number->string``, which round-trips ``1.7976931348623157e+308``;
+``-0.0`` compares equal to ``0.0`` under the parsed-value diff in
+:func:`roundtrip_common.verify`.
 """
 
-import json
 import os
 import shutil
 
@@ -47,100 +33,31 @@ import roundtrip_common
 
 from literalizer.languages import Scheme
 
-# `json.loads` returns this recursive shape; typing the walker against
-# it lets `isinstance` narrow cleanly under pyright, pyrefly, and ty
-# without `cast`.
-type JsonValue = (
-    None
-    | bool
-    | int
-    | float
-    | str
-    | list["JsonValue"]
-    | dict[str, "JsonValue"]
-)
-
 _VAR_NAME = "my-data"
 _LABEL = "Scheme"
 
 # `set-port-encoding!` pins stdout to UTF-8 so unicode string leaves
 # (e.g. ``"unicode é 中"``) survive the byte-level handoff to the
-# Python verifier regardless of the runner's locale.  The `normalize`
-# walker pairs each shape node with the matching sub-value inside the
-# literalized `my-data`: an `obj` shape consumes the flat alternating
-# key/value list (taking the value at every odd index) and returns an
-# alist of `(key . value)` pairs (the only object form `scm->json`'s
-# `json-valid?` accepts; see `json/builder.scm:188`), an `arr` shape
-# walks its children in lockstep with the literalized list and returns
-# a vector, and the `scalar` leaf passes the value straight through to
-# `scm->json`.  Indexing is done with hand-rolled accumulators so the
-# walker has no implicit dependency on SRFI-1 (`iota`).
+# Python verifier regardless of the runner's locale.  `(use-modules
+# (json))` is also emitted by the language's `static_preamble` under
+# `json_type=GUILE_JSON`, but repeating it here is harmless and keeps
+# the wrapper runnable in the default mode too.
 _HEADER = """\
 (use-modules (json))
 (set-port-encoding! (current-output-port) "UTF-8")
-
-(define (normalize shape data)
-  (cond
-    ((eq? shape (quote scalar)) data)
-    ((eq? (car shape) (quote obj))
-     (let loop ((entries (cdr shape)) (index 0) (acc (quote ())))
-       (if (pair? entries)
-           (loop (cdr entries)
-                 (+ index 1)
-                 (cons (cons (car (car entries))
-                             (normalize (cdr (car entries))
-                                        (list-ref data
-                                                  (+ (* index 2) 1))))
-                       acc))
-           (reverse acc))))
-    ((eq? (car shape) (quote arr))
-     (let loop ((children (cdr shape)) (index 0) (acc (quote ())))
-       (if (pair? children)
-           (loop (cdr children)
-                 (+ index 1)
-                 (cons (normalize (car children) (list-ref data index))
-                       acc))
-           (list->vector (reverse acc)))))))
 """
-
-
-def _scheme_string(text: str) -> str:
-    """Return a Scheme string literal whose value is *text*."""
-    escaped = text.replace("\\", "\\\\").replace('"', '\\"')
-    return f'"{escaped}"'
-
-
-def _shape(value: JsonValue) -> str:
-    """Return a Scheme datum describing the JSON shape of *value*.
-
-    Leaves render as the symbol ``scalar``; objects as
-    ``(obj ("k" . sub-shape) ...)``; arrays as ``(arr sub-shape ...)``.
-    The walker in ``_HEADER`` consumes this tree in lockstep with the
-    literalized ``my-data``.
-    """
-    if isinstance(value, dict):
-        entries = " ".join(
-            f"({_scheme_string(text=key)} . {_shape(value=sub)})"
-            for key, sub in value.items()
-        )
-        return f"(obj {entries})"
-    if isinstance(value, list):
-        children = " ".join(_shape(value=item) for item in value)
-        return f"(arr {children})"
-    return "scalar"
 
 
 def _build_program(json_text: str) -> str:
     """Return a runnable Scheme program literalized from *json_text*."""
     result = roundtrip_common.literalize_new_variable(
-        language=Scheme(),
+        language=Scheme(json_type=Scheme.json_types.GUILE_JSON),
         json_text=json_text,
         var_name=_VAR_NAME,
         pre_indent_level=0,
     )
     preamble = "\n".join((*result.preamble, *result.body_preamble))
-    shape_datum = _shape(value=json.loads(s=json_text))
-    emit = f"(scm->json (normalize (quote {shape_datum}) {_VAR_NAME}))"
+    emit = f"(scm->json {_VAR_NAME})"
     return f"{_HEADER}\n{preamble}\n{result.code}\n{emit}\n"
 
 


### PR DESCRIPTION
Follow-up to #2760. Now that `GUILE_JSON` mode renders objects as Scheme association lists, arrays as vectors, and null as the `'null` symbol that guile-json's `scm->json` accepts directly, the round-trip helper no longer needs its Python-emitted shape descriptor or generic `normalize` walker. This drops the `_shape` / `_HEADER normalize` machinery (and the `_scheme_string` helper, `JsonValue` type, and `json` import), switches `_build_program` to `Scheme(json_type=Scheme.json_types.GUILE_JSON)`, and reduces program emission to a single `(scm->json my-data)` line. `set-port-encoding!` and `(use-modules (json))` stay in the wrapper as harmless, and `excluded_keys=()` is kept. Verified end-to-end against guile-json 4.7.3 (the CI-pinned tag): the full document round-trips and `roundtrip_common.verify` passes.

Closes #2769

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only changes the Guile round-trip CI script and its generated test program; no production runtime or auth/data paths.
> 
> **Overview**
> The Scheme CI round-trip helper now literalizes JSON with **`Scheme(json_type=GUILE_JSON)`** so **`my-data`** is already alists, vectors, and **`'null`** for guile-json.
> 
> It **removes** the Python-built shape tree, **`normalize`** walker, and related helpers, and the emitted Guile program is just **`(scm->json my-data)`** after UTF-8 and **`(json)`** setup. Docs in **`run_scheme_roundtrip.py`** match this simpler path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6a0f537ab75df511fd4be2d7a18ef6b1c8d88a0a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->