### PR TITLE
Add Nix JSON round-trip CI check (#2666)

### DIFF
--- a/.github/scripts/run_nix_roundtrip.py
+++ b/.github/scripts/run_nix_roundtrip.py
@@ -1,0 +1,92 @@
+"""Nix JSON round-trip check (issue #2666).
+
+Literalize the shared ``roundtrip_input.json`` document to a Nix
+``let myData = {...}; in myData`` expression, write it to a ``main.nix``
+file, evaluate it with ``nix-instantiate --eval --strict --json`` so
+Nix's built-in JSON printer re-emits the value on stdout, and hand the
+emitted JSON to :func:`roundtrip_common.verify`.
+
+The JSON is produced by Nix's own ``--json`` evaluator output (the same
+``printValueAsJSON`` machinery behind ``builtins.toJSON``) rather than a
+hand-rolled walker, matching the issue's preference for a built-in JSON
+dumper.  ``--strict`` forces the lazy attribute set and its nested lists
+to be evaluated fully before serialization.
+
+This lives here, driven by the ``Nix roundtrip`` step of the
+``lint-fast`` job in ``.github/workflows/lint.yml``, because that job is
+where the ``nix-instantiate`` binary is installed (the ``Install Nix``
+step).  It shares the same input and comparison logic as the other
+per-language round-trip helpers.
+
+Two fields of the shared input are trimmed before literalization and
+excluded from the comparison:
+
+``biginteger``
+    The 26-digit value overflows Nix's signed 64-bit integers; the Nix
+    backend materializes it as ``builtins.fromJSON "999..."``, which
+    cannot represent the original magnitude on evaluation.
+
+``float_large_exponent``
+    ``1.7976931348623157e308`` sits at the edge of IEEE-754 double
+    range; trimming it matches the Ada and C round-trip scripts and
+    keeps the check independent of edge-of-range float printing.  The
+    remaining ``float`` (``3.14``), ``negative_zero``, and
+    container-nested doubles round-trip on Nix 2.12+ (which prints
+    floats at full precision rather than the older six-significant-digit
+    truncation).
+"""
+
+import shutil
+
+import roundtrip_common
+
+from literalizer.languages import Nix
+
+_VAR_NAME = "myData"
+_LABEL = "Nix"
+
+_EXCLUDED_KEYS = ("biginteger", "float_large_exponent")
+
+
+def _build_program(json_text: str) -> str:
+    """Return a runnable Nix program literalized from *json_text*."""
+    trimmed_json = roundtrip_common.trim_keys(
+        json_text=json_text,
+        excluded_keys=_EXCLUDED_KEYS,
+    )
+    result = roundtrip_common.literalize_new_variable(
+        language=Nix(),
+        json_text=trimmed_json,
+        var_name=_VAR_NAME,
+        pre_indent_level=0,
+    )
+    parts = (*result.preamble, *result.body_preamble, result.code)
+    return "\n".join(parts) + "\n"
+
+
+def main() -> None:
+    """Round-trip the shared document through the Nix backend."""
+    program = _build_program(json_text=roundtrip_common.read_input())
+    nix_instantiate = shutil.which(cmd="nix-instantiate") or "nix-instantiate"
+    roundtrip_common.execute(
+        label=_LABEL,
+        source_filename="main.nix",
+        program=program,
+        steps=[
+            roundtrip_common.Step(
+                args=[
+                    nix_instantiate,
+                    "--eval",
+                    "--strict",
+                    "--json",
+                    "./main.nix",
+                ],
+                failure_label="nix-instantiate error",
+            ),
+        ],
+        excluded_keys=_EXCLUDED_KEYS,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -435,6 +435,14 @@ jobs:
           find tests/integration/cases -name '*.nix' -print0 > /tmp/files-nix && test -s /tmp/files-nix
           xargs -0 -P "$(nproc)" -n1 nix-instantiate --parse < /tmp/files-nix > /dev/null
 
+      # Basic JSON -> Nix -> JSON round-trip (issue 2666). Runs here
+      # because this is the job with the `nix-instantiate` binary on PATH
+      # (the `Install Nix` step above); `uv run` (project mode, not
+      # `--no-project`) is required so `import literalizer` resolves.
+      # See `.github/scripts/run_nix_roundtrip.py`.
+      - name: Nix roundtrip
+        run: uv run python .github/scripts/run_nix_roundtrip.py
+
       - name: Lint Tcl
         run: |-
           find tests/integration/cases -name '*.tcl' -print0 > /tmp/files-tcl && test -s /tmp/files-tcl

--- a/newsfragments/2666.change
+++ b/newsfragments/2666.change
@@ -1,0 +1,1 @@
+Add a Nix JSON round-trip check to CI using the shared round-trip fixture, evaluating the literalized expression with ``nix-instantiate --eval --strict --json`` so that Nix's built-in JSON printer re-emits the value.


### PR DESCRIPTION
Resolves #2666 (sub-issue of #1867) by adding a Nix JSON round-trip check to the `lint-fast` CI job, where the Nix toolchain is already installed. The new `.github/scripts/run_nix_roundtrip.py` literalizes the shared `roundtrip_input.json` fixture to a Nix expression and evaluates it with `nix-instantiate --eval --strict --json` so Nix's built-in JSON printer re-emits the value for comparison, avoiding a hand-rolled serializer. It excludes `biginteger` (overflows Nix's signed 64-bit integers) and `float_large_exponent` (edge-of-range double), matching the C/Ada round-trip scripts; the remaining floats round-trip on the pinned Nix 2.34.7. A towncrier `2666.change` newsfragment is included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only addition reusing existing roundtrip_common and Nix literalization; no runtime or auth changes.
> 
> **Overview**
> Adds **Nix** to the shared JSON round-trip CI suite (#2666): a new `.github/scripts/run_nix_roundtrip.py` literalizes `roundtrip_input.json` via the existing `Nix` backend, evaluates `main.nix` with **`nix-instantiate --eval --strict --json`**, and compares stdout through `roundtrip_common` (same pattern as Lua, C, etc.).
> 
> The **`lint-fast`** workflow gains a **Nix roundtrip** step (after **Lint Nix**) where Nix is already installed. **`biginteger`** and **`float_large_exponent`** are trimmed from input and verification, aligned with Ada/C limits on 64-bit ints and edge doubles. A towncrier entry documents the change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bd97c8ad41d7c87035829f00e8baf05dbfb5883a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->