### PR TITLE
Rewrite C round-trip helper to use C(json_type=CJSON) (#2767)

### DIFF
--- a/.github/scripts/run_c_roundtrip.py
+++ b/.github/scripts/run_c_roundtrip.py
@@ -1,11 +1,10 @@
 """C JSON round-trip check (issue #2641).
 
 Literalize the shared ``roundtrip_input.json`` document to a C
-``CVal my_data = ((CVal){.m = (CKV[]){...}});`` declaration, wrap it
-in a tiny ``main`` that builds a parallel ``cJSON`` tree from
-``my_data`` and prints it via ``cJSON_PrintUnformatted``, compile with
-``clang -std=c99 -lcjson``, run it, and hand the emitted JSON to
-:func:`roundtrip_common.verify`.
+``cJSON *my_data = ...;`` declaration via ``C(json_type=CJSON)``, wrap
+it in a tiny ``main`` that prints ``cJSON_PrintUnformatted(my_data)`` to
+stdout, compile with ``clang -std=c99 -lcjson``, run it, and hand the
+emitted JSON to :func:`roundtrip_common.verify`.
 
 This lives here, driven by the ``C roundtrip`` step of the
 ``lint-fast`` job in ``.github/workflows/lint.yml``, because that job
@@ -14,23 +13,13 @@ step; the ``libcjson-dev`` apt package is installed by the same job.
 It shares the same input and comparison logic as the other
 per-language round-trip helpers.
 
-C ships no standard-library JSON encoder.  The literalizer's ``CVal``
-is also an *untagged* union -- the run-time carries no discriminator
-that would let a generic walker decide which member of ``.b`` /
-``.i`` / ``.f`` / ``.s`` / ``.a`` / ``.m`` is live.  So the *shape*
-of the round-trip document is encoded into the generated ``main`` by
-walking the parsed JSON in Python (same pattern as the Forth / Tcl
-helpers) and emitting one ``cJSON_Create*`` call per node that reads
-the slot matching the original JSON type.  Leaf escaping and number
-formatting are then handled by cJSON itself.
-
-This shape-driven walk is the consequence of ``CVal`` being untagged
-rather than of cJSON: any encoder (hand-rolled or otherwise) would
-need the same per-node dispatch.  Issue #2763 tracks adding a
-``C(json_type=...)`` knob that literalizes directly to a cJSON tree,
-which would let this helper drop the walker and just call
-``cJSON_PrintUnformatted`` (mirroring the C++ / Haskell / Zig /
-Crystal round-trip scripts).
+C ships no standard-library JSON encoder.  ``C(json_type=CJSON)``
+(issue #2766) literalizes the document directly into a ``cJSON`` node
+tree -- one ``cJSON_Create*`` call per node, composed with
+``cJSON_AddItemToArray`` / ``cJSON_AddItemToObject`` -- so this helper
+just calls ``cJSON_PrintUnformatted`` and no longer walks the parsed
+JSON in Python (mirroring the C++ / Haskell / Zig / Crystal round-trip
+scripts).
 
 Two fields are excluded from the comparison:
 
@@ -49,103 +38,18 @@ Two fields are excluded from the comparison:
   exceeds DBL_MAX) and trips the fallback test, so cJSON emits the
   rounded value anyway and the round-trip sees ``inf``.  The
   truncation happens inside cJSON's printer, not in the literalized
-  literal; excluded from the comparison rather than fixed.
+  tree; excluded from the comparison rather than fixed.
 """
 
-import json
 import shutil
 
 import roundtrip_common
 
 from literalizer.languages import C
 
-# ``json.loads`` returns this recursive shape; typing the walker
-# against it lets ``isinstance`` narrow cleanly under pyright,
-# pyrefly, and ty without ``cast``.
-type JsonValue = (
-    None
-    | bool
-    | int
-    | float
-    | str
-    | list["JsonValue"]
-    | dict[str, "JsonValue"]
-)
-
 _VAR_NAME = "my_data"
 _LABEL = "C"
 _EXCLUDED_KEYS = ("biginteger", "float_large_exponent")
-
-
-def _scalar_create(*, value: bool | float | str, access: str) -> str:
-    """Return a ``cJSON_Create*(...)`` expression for the *value* leaf.
-
-    ``bool`` is checked before ``int`` because Python treats ``True``
-    / ``False`` as ``int`` instances; both share the integer storage
-    slot in ``CVal`` but reach for different union members.  All
-    numbers go through ``cJSON_CreateNumber``, which takes a
-    ``double``; the integer ``access.i`` is widened explicitly so the
-    cast is visible in the generated source.
-    """
-    if isinstance(value, bool):
-        return f"cJSON_CreateBool({access}.b)"
-    if isinstance(value, int):
-        return f"cJSON_CreateNumber((double){access}.i)"
-    if isinstance(value, float):
-        return f"cJSON_CreateNumber({access}.f)"
-    return f"cJSON_CreateString({access}.s)"
-
-
-def _walk(
-    *,
-    value: JsonValue,
-    access: str,
-    name: str,
-    lines: list[str],
-) -> None:
-    """Append C statements that build a cJSON node from *access*.
-
-    The generated statements declare a fresh ``cJSON *<name>`` for
-    *value* and, for containers, recursively build each child with a
-    suffixed name before attaching it.  *access* is a C expression
-    evaluating to the ``CVal`` slot for *value*; the walker descends
-    through ``.a[i]`` for arrays and ``.m[i].v`` for objects, matching
-    the literalizer's ``(CVal[]){...}`` / ``(CKV[]){...}`` shape.
-    ``roundtrip_input`` is deliberately null-free.
-    """
-    if isinstance(value, list):
-        lines.append(f"cJSON *{name} = cJSON_CreateArray();")
-        for index, element in enumerate(value):
-            child = f"{name}_{index}"
-            _walk(
-                value=element,
-                access=f"{access}.a[{index}]",
-                name=child,
-                lines=lines,
-            )
-            lines.append(f"cJSON_AddItemToArray({name}, {child});")
-        return
-    if isinstance(value, dict):
-        lines.append(f"cJSON *{name} = cJSON_CreateObject();")
-        for index, sub in enumerate(value.values()):
-            child = f"{name}_{index}"
-            _walk(
-                value=sub,
-                access=f"{access}.m[{index}].v",
-                name=child,
-                lines=lines,
-            )
-            lines.append(
-                f"cJSON_AddItemToObject({name}, "
-                f"{access}.m[{index}].k, {child});",
-            )
-        return
-    if value is None:
-        message = "unsupported JSON null in round-trip input"
-        raise TypeError(message)
-    lines.append(
-        f"cJSON *{name} = {_scalar_create(value=value, access=access)};",
-    )
 
 
 def _build_program(*, json_text: str) -> str:
@@ -155,28 +59,22 @@ def _build_program(*, json_text: str) -> str:
         excluded_keys=_EXCLUDED_KEYS,
     )
     result = roundtrip_common.literalize_new_variable(
-        language=C(),
+        language=C(json_type=C.json_types.CJSON),
         json_text=trimmed_json,
         var_name=_VAR_NAME,
         pre_indent_level=1,
     )
-    parsed: JsonValue = json.loads(s=trimmed_json)
-    build_lines: list[str] = []
-    _walk(value=parsed, access=_VAR_NAME, name="root", lines=build_lines)
-    build_body = "\n    ".join(build_lines)
     preamble = "\n".join((*result.preamble, *result.body_preamble))
     return (
         f"{preamble}\n"
         "#include <stdio.h>\n"
         "#include <stdlib.h>\n"
-        "#include <cjson/cJSON.h>\n"
         "int main(void) {\n"
         f"{result.code}\n"
-        f"    {build_body}\n"
-        "    char *out = cJSON_PrintUnformatted(root);\n"
+        f"    char *out = cJSON_PrintUnformatted({_VAR_NAME});\n"
         "    fputs(out, stdout);\n"
         "    free(out);\n"
-        "    cJSON_Delete(root);\n"
+        f"    cJSON_Delete({_VAR_NAME});\n"
         "    return 0;\n"
         "}\n"
     )

--- a/newsfragments/2767.change
+++ b/newsfragments/2767.change
@@ -1,0 +1,1 @@
+Rewrite the C JSON round-trip CI check to literalize the shared fixture through ``C(json_type=C.json_types.CJSON)`` and print it with ``cJSON_PrintUnformatted``, dropping the Python-side walker that previously built a parallel ``cJSON`` tree from the parsed input. The check still reports ``C round-trip OK`` with the same two excluded fields.


### PR DESCRIPTION
Rewrites `.github/scripts/run_c_roundtrip.py` to literalize the shared fixture directly into a `cJSON` node tree via the `C(json_type=CJSON)` knob added in #2766, then print it with `cJSON_PrintUnformatted`. This drops the Python-side walker (`_walk` / `_scalar_create` / the `JsonValue` alias) and the manual tree-build loop in `main`, since the literalized `result.code` now ends with `cJSON *my_data = _n0;` and the cJSON header flows in via `result.preamble`. The same two fields (`biginteger`, `float_large_exponent`) stay excluded, and the check still reports `C round-trip OK`. No CI changes are needed (the `libcjson-dev` install and `-lcjson` link were already added in #2641/#2766). Closes #2767 (sub-issue of #2763 / #1867).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only refactor of an existing round-trip script; no runtime library or workflow changes beyond the same check using a simpler code path.
> 
> **Overview**
> The **C JSON round-trip** CI helper (`.github/scripts/run_c_roundtrip.py`) now literalizes the shared fixture with **`C(json_type=C.json_types.CJSON)`** into a `cJSON *` tree and prints it with **`cJSON_PrintUnformatted(my_data)`**, instead of emitting a **`CVal`** literal and rebuilding a parallel tree in Python via **`_walk`** / **`_scalar_create`**.
> 
> That removes roughly **100 lines** of walker code, the **`JsonValue`** typing alias, **`json.loads`**, and the extra **`#include <cjson/cJSON.h>`** in `main` (cJSON headers come from the literalizer preamble). **`main`** prints and deletes **`my_data`** directly. **`biginteger`** and **`float_large_exponent`** stay excluded; behavior and **`C round-trip OK`** messaging are unchanged. A **newsfragment** documents the change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cffdd69d0d6c1feee795eb126e3fbd171ad11283. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->