### PR TITLE
Add MATLAB JSON round-trip check (#2663)

### DIFF
--- a/.github/scripts/run_matlab_roundtrip.py
+++ b/.github/scripts/run_matlab_roundtrip.py
@@ -1,0 +1,73 @@
+"""MATLAB JSON round-trip check (issue #2663).
+
+Literalize the shared ``roundtrip_input.json`` document to a MATLAB
+``myData = ...;`` assignment, append a line that prints
+``jsonencode(myData)``, run the script, and hand the emitted JSON to
+:func:`roundtrip_common.verify`.
+
+This lives here, driven by the ``MATLAB roundtrip`` step of the
+``lint-matlab`` job in ``.github/workflows/lint.yml``, because that job
+is where the MATLAB toolchain is installed.  As with the ``Lint Matlab``
+parse check, the toolchain is Octave (``gnuoctave/octave``), a practical
+CI substitute for MATLAB; ``jsonencode`` is the built-in serializer
+shared by both.  This script shares the same input and comparison logic
+as the other per-language round-trip helpers.
+
+One field is excluded from the comparison because MATLAB's number type
+cannot represent it losslessly:
+
+* ``biginteger`` -- MATLAB has only the IEEE-754 ``double`` numeric
+  type, so the 26-digit literal is stored as a double and
+  ``jsonencode`` re-emits it as ``1e26``.  The field is trimmed from the
+  input *before* literalization so the generated program does not carry
+  a value the round-trip would reject.
+"""
+
+import shutil
+
+import roundtrip_common
+
+from literalizer.languages import Matlab
+
+_VAR_NAME = "myData"
+_LABEL = "MATLAB"
+_EXCLUDED_KEYS = ("biginteger",)
+
+
+def _build_program(json_text: str) -> str:
+    """Return a runnable MATLAB program literalized from *json_text*."""
+    trimmed_json = roundtrip_common.trim_keys(
+        json_text=json_text,
+        excluded_keys=_EXCLUDED_KEYS,
+    )
+    result = roundtrip_common.literalize_new_variable(
+        language=Matlab(),
+        json_text=trimmed_json,
+        var_name=_VAR_NAME,
+        pre_indent_level=0,
+    )
+    preamble = "\n".join((*result.preamble, *result.body_preamble))
+    emit = f'printf("%s", jsonencode({_VAR_NAME}));'
+    return f"{preamble}\n{result.code}\n{emit}\n"
+
+
+def main() -> None:
+    """Round-trip the shared document through the MATLAB backend."""
+    program = _build_program(json_text=roundtrip_common.read_input())
+    octave = shutil.which(cmd="octave") or "octave"
+    roundtrip_common.execute(
+        label=_LABEL,
+        source_filename="main.m",
+        program=program,
+        steps=[
+            roundtrip_common.Step(
+                args=[octave, "--norc", "--no-gui", "main.m"],
+                failure_label="octave runtime error",
+            ),
+        ],
+        excluded_keys=_EXCLUDED_KEYS,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/run_matlab_roundtrip.py
+++ b/.github/scripts/run_matlab_roundtrip.py
@@ -47,7 +47,7 @@ def _build_program(json_text: str) -> str:
         pre_indent_level=0,
     )
     preamble = "\n".join((*result.preamble, *result.body_preamble))
-    emit = f'printf("%s", jsonencode({_VAR_NAME}));'
+    emit = f'fprintf("%s", jsonencode({_VAR_NAME}));'
     return f"{preamble}\n{result.code}\n{emit}\n"
 
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -746,6 +746,20 @@ jobs:
           find tests/integration/cases -name 'Matlab*.m' -print0 > /tmp/files-matlab && test -s /tmp/files-matlab
           xargs -0 -P "$(nproc)" -n1 bash .github/scripts/lint-matlab-fixture.sh < /tmp/files-matlab
 
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8.1.0
+        with:
+          enable-cache: true
+          cache-dependency-glob: '**/pyproject.toml'
+
+      # Basic JSON -> MATLAB -> JSON round-trip (issue 2663). Runs here
+      # because this is the job with the MATLAB toolchain (Octave, the
+      # practical CI substitute) already installed; `uv run` (project
+      # mode, not `--no-project`) is required so `import literalizer`
+      # resolves. See `.github/scripts/run_matlab_roundtrip.py`.
+      - name: MATLAB roundtrip
+        run: uv run python .github/scripts/run_matlab_roundtrip.py
+
   lint-perl:
     runs-on: ubuntu-latest
     timeout-minutes: 10

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -752,6 +752,15 @@ jobs:
           enable-cache: true
           cache-dependency-glob: '**/pyproject.toml'
 
+      # Unlike the other round-trip jobs, this one runs inside a
+      # container, so the checked-out workspace is owned by a different
+      # uid than the container user. Git then refuses to operate on it
+      # ("dubious ownership"), which breaks the `setuptools_scm` version
+      # lookup that `uv run` triggers when it builds `literalizer`. Mark
+      # the workspace safe so that build succeeds.
+      - name: Mark workspace as a safe git directory
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
       # Basic JSON -> MATLAB -> JSON round-trip (issue 2663). Runs here
       # because this is the job with the MATLAB toolchain (Octave, the
       # practical CI substitute) already installed; `uv run` (project

--- a/newsfragments/2663.change
+++ b/newsfragments/2663.change
@@ -1,0 +1,1 @@
+Add a MATLAB JSON round-trip check to CI using the shared round-trip fixture, serializing the literalized ``myData`` value with the built-in ``jsonencode``; the 26-digit ``biginteger`` field is excluded because MATLAB's only numeric type is the IEEE 754 ``double``, which re-emits it as ``1e26``.


### PR DESCRIPTION
Closes #2663.

Applies the shared per-language JSON round-trip setup (issue #1867) to MATLAB.

## What

- `.github/scripts/run_matlab_roundtrip.py`: literalizes the shared `roundtrip_input.json` to a MATLAB `myData = struct(...)` assignment, appends `printf("%s", jsonencode(myData))`, runs it, and verifies the emitted JSON parses back to the original value. Modeled on the PowerShell helper.
- `.github/workflows/lint.yml`: adds `Install uv` + `MATLAB roundtrip` steps to the existing `lint-matlab` job, which already runs in the `gnuoctave/octave:9.2.0` container (Octave is the practical CI substitute for MATLAB, as used by the existing parse-check step).
- `newsfragments/2663.change`.

## Notes

- `jsonencode` is the built-in serializer shared by MATLAB and Octave, so no hand-rolled serializer is needed.
- The 26-digit `biginteger` field is excluded: MATLAB's only numeric type is the IEEE 754 `double`, which re-emits it as `1e26`. Every other field in the shared document (wide-exponent floats, negative zero, unicode/escaped strings, nested arrays/objects, heterogeneous arrays) round-trips.

## Testing

Verified end-to-end inside the actual `gnuoctave/octave:9.2.0` container (uv builds the project, runs the script): `MATLAB round-trip OK`. `ruff`, `yamlfix`, `actionlint`, and the manual Sphinx `spelling` build all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only workflow and helper script; no runtime product code paths, with a documented numeric comparison exception for `biginteger`.
> 
> **Overview**
> Adds **MATLAB/Octave** to the shared per-language JSON round-trip CI (issue #2663), alongside the existing PowerShell-style helpers.
> 
> A new **`.github/scripts/run_matlab_roundtrip.py`** literalizes `roundtrip_input.json` to `myData`, runs **`jsonencode`** via **`fprintf`**, executes the script with **Octave** in the `gnuoctave/octave` container, and verifies output with **`roundtrip_common`**. The **`biginteger`** field is stripped before literalization and excluded from comparison because MATLAB only has **`double`**, which re-serializes the 26-digit value as **`1e26`**.
> 
> **`.github/workflows/lint.yml`** extends **`lint-matlab`** with **`setup-uv`**, a **`safe.directory`** git config (needed for **`setuptools_scm`** when the job runs in a container with mismatched ownership), and a **`MATLAB roundtrip`** step. A **`newsfragments/2663.change`** entry documents the behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cbed3b9f24fc0df393a7922c57f1d8c6414898d6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->