### PR TITLE
Add Norg JSON round-trip check (#2667)

### DIFF
--- a/.github/scripts/run_norg_roundtrip.py
+++ b/.github/scripts/run_norg_roundtrip.py
@@ -1,0 +1,112 @@
+"""Norg JSON round-trip check (issue #2667).
+
+Literalize the shared ``roundtrip_input.json`` document to a Norg
+``* my_data`` heading whose value rides inside a ``@code json`` ranged
+verbatim tag, parse the resulting Norg document with the
+``tree-sitter-norg`` grammar, pull the verbatim block's text back out,
+and hand it to :func:`roundtrip_common.verify`.
+
+Unlike the executable-language round-trips, there is no language runtime
+to invoke: the analogous "back to JSON" step is a Norg parser recovering
+the embedded code block.  The :class:`literalizer.languages.Norg`
+backend stores the literal as a JSON code block, so once the grammar
+hands back the verbatim text the stdlib ``json`` parser re-emits the
+parsed value directly -- no hand-rolled serializer is needed.
+
+The parser is the same ``tree-sitter-norg`` grammar the ``Lint Norg``
+syntax check uses, loaded here through the ``tree-sitter`` Python
+binding.  The compiled shared library is built by the ``Build
+tree-sitter-norg parser`` step of the ``lint-npm-installed`` job in
+``.github/workflows/lint.yml`` and its path is passed in through the
+``LITERALIZER_NORG_PARSER`` environment variable; that job is therefore
+where the ``Norg roundtrip`` step lives.  It shares the same input and
+comparison logic as the other per-language round-trip helpers.
+"""
+
+import ctypes
+import json
+import os
+import sys
+
+import roundtrip_common
+from tree_sitter import Language, Parser
+
+from literalizer import InputFormat, NewVariable, literalize
+from literalizer.languages import Norg
+
+_VAR_NAME = "my_data"
+_LABEL = "Norg"
+_CONTENT_NODE_TYPE = "ranged_verbatim_tag_content"
+
+
+def _build_document(json_text: str) -> str:
+    """Return a Norg document literalized from *json_text*."""
+    result = literalize(
+        source=json_text,
+        input_format=InputFormat.JSON,
+        language=Norg(),
+        pre_indent_level=0,
+        include_delimiters=True,
+        variable_form=NewVariable(name=_VAR_NAME),
+        wrap_in_file=False,
+    )
+    return f"{result.code}\n"
+
+
+def _load_norg_language(library_path: str) -> Language:
+    """Load the compiled ``tree-sitter-norg`` grammar at *library_path*.
+
+    The ``tree-sitter`` binding expects the grammar pointer wrapped in a
+    ``PyCapsule`` named ``tree_sitter.Language``; ``ctypes`` only hands
+    back a raw address, so :c:func:`PyCapsule_New` rewraps it before the
+    :class:`Language` constructor sees it.
+    """
+    library = ctypes.cdll.LoadLibrary(name=library_path)
+    library.tree_sitter_norg.restype = ctypes.c_void_p
+    new_capsule = ctypes.pythonapi.PyCapsule_New
+    new_capsule.restype = ctypes.py_object
+    new_capsule.argtypes = [ctypes.c_void_p, ctypes.c_char_p, ctypes.c_void_p]
+    capsule: object = new_capsule(
+        library.tree_sitter_norg(),
+        b"tree_sitter.Language",
+        None,
+    )
+    return Language(capsule)
+
+
+def _extract_code_block(document: str, language: Language) -> str:
+    """Return the text of *document*'s single ``@code`` verbatim block."""
+    parser = Parser(language=language)
+    tree = parser.parse(document.encode(encoding="utf-8"))
+    pending = [tree.root_node]
+    while pending:
+        node = pending.pop()
+        if node.type == _CONTENT_NODE_TYPE and node.text is not None:
+            return node.text.decode(encoding="utf-8")
+        pending.extend(node.children)
+    sys.stderr.write(
+        f"{_LABEL}: no {_CONTENT_NODE_TYPE} node found\n"
+        f"\nProgram:\n{document}\n",
+    )
+    sys.exit(1)
+
+
+def main() -> None:
+    """Round-trip the shared document through the Norg backend."""
+    document = _build_document(json_text=roundtrip_common.read_input())
+    language = _load_norg_language(
+        library_path=os.environ["LITERALIZER_NORG_PARSER"],
+    )
+    code_block = _extract_code_block(document=document, language=language)
+    parsed: dict[str, object] = json.loads(s=code_block)
+    produced_json = json.dumps(obj=parsed)
+    roundtrip_common.verify(
+        label=_LABEL,
+        produced_json=produced_json,
+        exclude_keys=(),
+    )
+    sys.stdout.write(f"{_LABEL} round-trip OK\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -861,6 +861,13 @@ jobs:
             /tmp/tree-sitter-norg/src/parser.c \
             -x c++ /tmp/tree-sitter-norg/src/scanner.cc \
             -lstdc++
+      # `uv` is needed by the `Norg roundtrip` step below; it runs the
+      # helper in project mode so `import literalizer` resolves.
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8.1.0
+        with:
+          enable-cache: true
+          cache-dependency-glob: '**/pyproject.toml'
 
       - name: Lint Json5
         run: |-
@@ -871,6 +878,17 @@ jobs:
         run: |-
           find tests/integration/cases -name '*.norg' -print0 > /tmp/files-norg && test -s /tmp/files-norg
           xargs -0 tree-sitter parse --lib-path /tmp/norg.so --lang-name norg --quiet < /tmp/files-norg
+      # Basic JSON -> Norg -> JSON round-trip (issue 2667). Runs here
+      # because this is the job that builds the `tree-sitter-norg` grammar
+      # (`/tmp/norg.so`) the helper loads through the `tree-sitter` Python
+      # binding; `uv run` (project mode, not `--no-project`) is required so
+      # `import literalizer` resolves, and `--with` layers `tree-sitter` on
+      # top. The grammar's path is passed via `LITERALIZER_NORG_PARSER`.
+      # See `.github/scripts/run_norg_roundtrip.py`.
+      - name: Norg roundtrip
+        env:
+          LITERALIZER_NORG_PARSER: /tmp/norg.so
+        run: uv run --with 'tree-sitter==0.25.2' python .github/scripts/run_norg_roundtrip.py
 
       # ``tsc`` parses these ``.ts`` fixtures at
       # ``TypeScript.language_version`` (``V5``) in

--- a/newsfragments/2667.change
+++ b/newsfragments/2667.change
@@ -1,0 +1,1 @@
+Add a Norg JSON round-trip check to CI using the shared round-trip fixture.  The literalizer stores the value inside a ``@code json`` ranged verbatim tag, so the check parses the generated document with the ``tree-sitter-norg`` grammar, pulls the embedded code block back out, and re-parses it with the standard library ``json`` module.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,6 +92,12 @@ optional-dependencies.dev = [
     "sphinxcontrib-towncrier==0.5.0a0",
     "strict-kwargs==2026.5.20",
     "towncrier==25.8.0",
+    # ``tree-sitter`` resolves the ``tree-sitter-norg`` grammar for the
+    # ``Norg roundtrip`` check (``.github/scripts/run_norg_roundtrip.py``);
+    # listed here so the type checkers resolve its (``py.typed``) imports.
+    # Keep in sync with the ``--with`` pin in the ``Norg roundtrip`` step
+    # of ``.github/workflows/lint.yml``.
+    "tree-sitter==0.25.2",
     "ty==0.0.40",
     "types-pygments==2.20.0.20260518",
     "vulture==2.16",


### PR DESCRIPTION
Adds a Norg JSON round-trip check to CI, the #2667 sub-issue of #1867. Because the literalizer stores the value inside a `@code json` ranged verbatim tag, the new `.github/scripts/run_norg_roundtrip.py` literalizes the shared fixture to Norg, parses it back with the `tree-sitter-norg` grammar (loaded through the `tree-sitter` Python binding), and re-parses the recovered block with the stdlib `json` module rather than a hand-rolled serializer. The check is wired into the `lint-npm-installed` job that already builds the grammar (`/tmp/norg.so`), with an added `Install uv` step and the grammar path passed via `LITERALIZER_NORG_PARSER`. `tree-sitter==0.25.2` is added to the `dev` extra solely so the type checkers resolve its imports; the runtime layers it on with `--with`. A towncrier `newsfragments/2667.change` documents the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only CI and dev dependency wiring; no changes to literalizer runtime behavior for end users.
> 
> **Overview**
> Adds **CI coverage** for Norg as part of the shared JSON round-trip suite (#2667): a new helper literalizes the common fixture to Norg (`@code json` verbatim), parses the document with **tree-sitter-norg** to recover the embedded JSON, and compares via `roundtrip_common.verify`—no Norg runtime execution.
> 
> The check runs in the **`lint-npm-installed`** job (same place `/tmp/norg.so` is built), with **`Install uv`** and a **`Norg roundtrip`** step that sets `LITERALIZER_NORG_PARSER` and runs `uv run --with tree-sitter==0.25.2`. **`tree-sitter==0.25.2`** is added to the **`dev`** extra so type checkers resolve imports, aligned with the workflow pin. A **towncrier** fragment records the user-facing note.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7cca2ceb96c24fd44ce4b0183e802bc6294bca5d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->