### PR TITLE
Document why Occam has no JSON round-trip test (#2669)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1073,6 +1073,25 @@ jobs:
           find tests/integration/cases -name '*.occ' -print0 > /tmp/files-occam && test -s /tmp/files-occam
           xargs -0 -P "$(nproc)" -n1 uv run --no-project python .github/scripts/check_occam_syntax.py < /tmp/files-occam
 
+      # There is deliberately no Occam JSON round-trip (issues 1867 and 2669),
+      # unlike every other language.  A round-trip must compile and run the
+      # literalized program so it re-emits JSON on stdout, and for Occam there
+      # is no toolchain that can do this:
+      #
+      # 1. The backend models a JSON value as a "MOBILE DATA TYPE LIT IS CASE"
+      #    tagged union with recursive "MOBILE []MOBILE LIT" children.  That
+      #    tagged-union-over-DATA-TYPE construct is not part of the occam-pi
+      #    language, so no compiler accepts it.
+      # 2. KRoC (the only maintained occam-pi compiler, last updated 2020)
+      #    cannot parse the construct, rejects the underscores in identifiers
+      #    such as ``my_data``, and uses ``*`` rather than ``\`` as its string
+      #    escape character -- the same blockers documented for "Lint Occam"
+      #    above, which is why that step is a Python structural checker rather
+      #    than a real compile.
+      #
+      # Because nothing can execute the literalized output, Occam is the one
+      # issue-1867 language with no ``run_occam_roundtrip.py`` helper.
+
       - name: Lint Toml
         run: |-
           find tests/integration/cases -name '*.toml' -print0 > /tmp/files-toml && test -s /tmp/files-toml


### PR DESCRIPTION
Occam is the one issue-1867 language without a round-trip helper because no toolchain can compile and run the literalizer's output. The backend emits a non-standard `MOBILE DATA TYPE ... CASE` tagged union with recursive children that KRoC (the only maintained occam-pi compiler) cannot parse, and which is not part of the occam-pi language. Since a round-trip must execute the program and nothing can, this PR adds a comment next to the `Lint Occam` step in `lint.yml` documenting why there is deliberately no `run_occam_roundtrip.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment-only change to CI workflow; no runtime, auth, or test execution impact.
> 
> **Overview**
> Adds a **comment block** in `.github/workflows/lint.yml` immediately after the **Lint Occam** step, in the `lint-uv-scripts` job.
> 
> The new text explains why Occam is the only issue-1867 language **without** a `run_occam_roundtrip.py` CI step: round-trips require compiling and running literalized output to re-emit JSON, but no occam-pi toolchain can handle the backend’s `MOBILE DATA TYPE LIT IS CASE` tagged union (including recursive `MOBILE []MOBILE LIT`), and KRoC—the only maintained compiler—has the same limitations already documented for the Python structural linter (underscores in names like `my_data`, `*` vs `\` string escapes).
> 
> **No workflow behavior changes**—only documentation for reviewers and future maintainers (issues 1867 and 2669).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 16f6f2a971d5b6a35353b45d11049103723791be. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->