### PR TITLE
Lead docs landing examples with a minimal literalize call (#2791)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -31,41 +31,52 @@ Requires Python |minimum-python-version|\+.
 Usage
 -----
 
+Pass your data, its format, and a target language:
+
 .. code-block:: python
 
-   """Example of using literalizer."""
+   """Minimal example of using literalizer."""
+
+   from literalizer import InputFormat, literalize
+   from literalizer.languages import Python
+
+   result = literalize(
+       source='{"x": 1}',
+       input_format=InputFormat.JSON,
+       language=Python(),
+   )
+   # result.code:
+   # {
+   #     "x": 1,
+   # }
+
+Configure the language to control how individual data types are rendered.
+Comments in the source are preserved using the target language's comment syntax:
+
+.. code-block:: python
+
+   """Layering format options on top of the minimal call."""
 
    from literalizer import InputFormat, literalize
    from literalizer.languages import Go
 
-   # YAML comments are preserved using the target language's comment syntax
    yaml_config = """\
    # Server configuration
    host: localhost  # default host
    port: 8080
-   # Enable debug mode for development
-   debug: true
+   released: 2026-06-02
    """
    result = literalize(
        source=yaml_config,
        input_format=InputFormat.YAML,
-       language=Go(
-           date_format=Go.date_formats.GO,
-           datetime_format=Go.datetime_formats.GO,
-           bytes_format=Go.bytes_formats.HEX,
-           sequence_format=Go.sequence_formats.SLICE,
-       ),
-       pre_indent_level=0,
-       include_delimiters=True,
-       variable_form=None,
+       language=Go(date_format=Go.date_formats.ISO),
    )
-   # result:
+   # result.code:
    # map[string]any{
    #     // Server configuration
    #     "host": "localhost",  // default host
    #     "port": 8080,
-   #     // Enable debug mode for development
-   #     "debug": true,
+   #     "released": "2026-06-02",
    # }
 
 Use cases

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -21,43 +21,53 @@ Requires Python |minimum-python-version|\+.
 Usage
 -----
 
-Use :func:`literalizer.literalize` to convert data to native language literals:
+Use :func:`literalizer.literalize` to convert data to native language literals.
+Pass your data, its format, and a target language:
 
 .. code-block:: python
 
-   """Example of using literalizer."""
+   """Minimal example of using literalizer."""
+
+   from literalizer import InputFormat, literalize
+   from literalizer.languages import Python
+
+   result = literalize(  # returns LiteralizeResult with .code and .preamble
+       source='{"x": 1}',
+       input_format=InputFormat.JSON,
+       language=Python(),
+   )
+   # result.code:
+   # {
+   #     "x": 1,
+   # }
+
+Configure the language to control how individual data types are rendered.
+Comments in the source are preserved using the target language's comment syntax:
+
+.. code-block:: python
+
+   """Layering format options on top of the minimal call."""
 
    from literalizer import InputFormat, literalize
    from literalizer.languages import Go
 
-   # YAML comments are preserved using the target language's comment syntax
    yaml_config = """\
    # Server configuration
    host: localhost  # default host
    port: 8080
-   # Enable debug mode for development
-   debug: true
+   released: 2026-06-02
    """
-   result = literalize(  # returns LiteralizeResult with .code and .preamble
+   result = literalize(
        source=yaml_config,
        input_format=InputFormat.YAML,
-       language=Go(
-           date_format=Go.date_formats.GO,
-           datetime_format=Go.datetime_formats.GO,
-           bytes_format=Go.bytes_formats.HEX,
-           sequence_format=Go.sequence_formats.SLICE,
-       ),
-       pre_indent_level=0,
-       include_delimiters=True,
-       variable_form=None,
+       language=Go(date_format=Go.date_formats.ISO),
    )
    # result.code:
    # map[string]any{
    #     // Server configuration
    #     "host": "localhost",  // default host
    #     "port": 8080,
-   #     // Enable debug mode for development
-   #     "debug": true,
+   #     "released": "2026-06-02",
    # }
 
 Use cases

--- a/newsfragments/2791.change
+++ b/newsfragments/2791.change
@@ -1,0 +1,1 @@
+Lead the README and documentation home page with a minimal ``literalize`` call so that the required arguments are obvious at a glance, and move the format-option configuration into a follow-up example instead of mixing default-valued arguments into the first example.


### PR DESCRIPTION
Closes #2791.

## What

The first usage example in both `README.rst` and `docs/source/index.rst` led with a fully-configured `Go(...)` call plus three arguments (`pre_indent_level=0`, `include_delimiters=True`, `variable_form=None`) that were all being passed at their defaults, hiding what is actually required.

## Changes

- Lead both files with a minimal call: `literalize(source='{"x": 1}', input_format=InputFormat.JSON, language=Python())` and show its output.
- Follow with a second example that layers a format option (`Go(date_format=Go.date_formats.ISO)`) onto a YAML config, motivating format options and keeping the comment-preservation showcase.
- Remove all default-valued arguments from the headline examples.

## Verification

Ran doccmd over the changed docs: ruff, mypy, pylint, interrogate, vulture all pass; both examples were executed and their `# result.code:` output comments confirmed accurate. Sphinx spelling and doc8 pass (including the rendered newsfragment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and changelog text only; no runtime or API behavior changes.
> 
> **Overview**
> The **README** and **docs home page** usage sections are restructured so newcomers see the smallest valid `literalize` call first (`source`, `input_format`, `language=Python()`), with a second example that adds **Go** date formatting and YAML comment preservation.
> 
> The old single **Go** example that passed several **default** arguments (`pre_indent_level`, `include_delimiters`, `variable_form`, and many `Go(...)` format knobs) is removed from the lead position. Sample data and expected `# result.code` blocks are updated accordingly. A **newsfragment** records the change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cd7d7ccf3b54e70123a4a54a9aaff271ae502476. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->