### PR TITLE
Restructure api-reference.rst into sections; reconsider :undoc-members: (#2798)

### DIFF
--- a/docs/source/api-reference.rst
+++ b/docs/source/api-reference.rst
@@ -1,13 +1,164 @@
 API Reference
 =============
 
-.. automodule:: literalizer
+.. currentmodule:: literalizer
+
+Everything documented here is importable directly from the top-level
+``literalizer`` package (exceptions live in :mod:`literalizer.exceptions`).
+
+Core functions
+--------------
+
+.. autofunction:: literalize
+
+.. autofunction:: literalize_call
+
+Result type
+-----------
+
+.. autoclass:: LiteralizeResult
+   :members:
+
+Variable forms
+--------------
+
+The ``bound_refs`` argument to :func:`literalize` and :func:`literalize_call`
+describes each referenced name as one of these forms.
+
+.. autoclass:: NewVariable
+   :members:
    :undoc-members:
+
+.. autoclass:: ExistingVariable
+   :members:
+   :undoc-members:
+
+.. autoclass:: BothVariableForms
+   :members:
+   :undoc-members:
+
+.. autodata:: VariableForm
+
+.. autoclass:: ModifierCombination
+   :members:
+   :undoc-members:
+
+Identifier cases
+----------------
+
+.. autoclass:: IdentifierCase
+   :members:
+   :undoc-members:
+
+.. autodata:: ALL_REF_CASES
+
+.. autodata:: NON_KEBAB_REF_CASES
+
+Function calls
+--------------
+
+.. autoclass:: CallContext
+   :members:
+   :undoc-members:
+
+A language renders a call using one of these call styles.
+
+.. autodata:: CallStyle
+
+.. autoclass:: PositionalCallStyle
+   :members:
+   :undoc-members:
+
+.. autoclass:: KeywordCallStyle
+   :members:
+   :undoc-members:
+
+.. autoclass:: ObjectCallStyle
+   :members:
+   :undoc-members:
+
+.. autoclass:: PrefixCallStyle
+   :members:
+   :undoc-members:
+
+.. autoclass:: PostfixCallStyle
+   :members:
+   :undoc-members:
+
+.. autoclass:: CommandCallStyle
+   :members:
+   :undoc-members:
+
+.. autoclass:: StubReturn
+   :members:
+   :undoc-members:
+
+Input formats
+-------------
+
+.. autoclass:: InputFormat
+   :members:
+   :undoc-members:
+
+Formatting configuration
+------------------------
+
+Building blocks used when defining how a language renders collections,
+comments and scalars.
+
+.. autoclass:: CollectionLayout
+   :members:
+   :undoc-members:
+
+.. autoclass:: TrailingCommaConfig
+   :members:
+   :undoc-members:
+
+.. autoclass:: CommentConfig
+   :members:
+   :undoc-members:
+
+.. autoclass:: SequenceFormatConfig
+   :members:
+   :undoc-members:
+
+.. autoclass:: SetFormatConfig
+   :members:
+   :undoc-members:
+
+.. autoclass:: DictFormatConfig
+   :members:
+   :undoc-members:
+
+.. autoclass:: OrderedMapFormatConfig
+   :members:
+   :undoc-members:
+
+.. autoclass:: DateFormatConfig
+   :members:
+   :undoc-members:
+
+.. autoclass:: DatetimeFormatConfig
+   :members:
+   :undoc-members:
+
+.. autofunction:: fixed_open
+
+Defining a language
+-------------------
+
+The :class:`Language` protocol describes how a language formats literals.
+Concrete, built-in languages are listed in :doc:`languages`; the members
+below are the contract each one implements.
+
+.. autoclass:: Language
+   :members:
+
+.. autoclass:: LanguageCls
    :members:
 
 Exceptions
 ----------
 
 .. automodule:: literalizer.exceptions
-   :undoc-members:
    :members:

--- a/newsfragments/2798.change
+++ b/newsfragments/2798.change
@@ -1,0 +1,1 @@
+Restructured the API reference into labeled sections (core functions, result type, variable forms, identifier cases, function calls, formatting configuration, language definition and exceptions) and stopped surfacing undocumented internals on the page.


### PR DESCRIPTION
Closes #2798.

## Problem

`docs/source/api-reference.rst` was two bare `automodule` directives with `:undoc-members:`, producing an undifferentiated dump that mixed documented API with undocumented members in no deliberate order. The biggest offender: the `LanguageCls` metaclass leaked ~80 undocumented internal attributes onto a user-facing page.

## Change

- Group the reference into deliberate sections: **Core functions** (`literalize`, `literalize_call`), **Result type** (`LiteralizeResult`), **Variable forms** (`NewVariable` / `ExistingVariable` / `BothVariableForms` / `VariableForm` / `ModifierCombination`), **Identifier cases** (`IdentifierCase`, `ALL_REF_CASES`, `NON_KEBAB_REF_CASES`), **Function calls** (`CallContext` + call styles + `StubReturn`), **Input formats** (`InputFormat`), **Formatting configuration** (the layout/comment/collection/date config blocks + `fixed_open`), **Defining a language** (`Language` / `LanguageCls`), and **Exceptions**.
- Replace the bare `automodule` with explicit `autofunction` / `autoclass` / `autodata` directives so ordering is intentional.
- Apply `:undoc-members:` per directive instead of globally. This drops the `LanguageCls` internal-attribute dump while keeping genuine API surface visible (enum variants such as `InputFormat.JSON`, union aliases `VariableForm` / `CallStyle`, and the config dataclass fields).

All cross-references from the other docs pages (e.g. `Language.supported_ref_cases`, `LiteralizeResult.preamble`) still resolve.

## Verification

`sphinx-build -M html` (with `-W`), `-M spelling` (with `-W`), and `-M linkcheck` all succeed. Pre-commit doc hooks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to Sphinx directives and newsfragment; no runtime or library behavior changes.
> 
> **Overview**
> The **API reference** page is reorganized from two blanket `automodule` blocks into named sections (core APIs, variable forms, calls, formatting config, language protocol, exceptions) with explicit `autofunction` / `autoclass` / `autodata` entries so order and scope are intentional.
> 
> `:undoc-members:` is applied **per symbol** instead of globally, which removes the large undocumented dump from `LanguageCls` while still exposing needed enum/alias/config surface where appropriate. The exceptions page now documents **members only** (`:members:`), not undocumented internals.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3a10138e0fe33228e14bdd2f77d0a6fd9c7b64fa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->