### PR TITLE
Docs: collapse JSON value types section into a table (#2794)

### DIFF
--- a/docs/source/languages.rst
+++ b/docs/source/languages.rst
@@ -122,10 +122,9 @@ JSON value types
 ----------------
 
 Some languages also have a single runtime JSON value type that is a better
-fit than native narrow collection types.  Rust, Crystal, Java, Kotlin,
-Scala, C#, F#, Nim, Haskell, Zig, C++, OCaml, Elm, PureScript, Erlang,
-Odin, and D support this through the ``json_type`` constructor argument (D's
-polarity is reversed; see below):
+fit than native narrow collection types.  These languages support this
+through the ``json_type`` constructor argument, accessed as
+``<Language>.json_types.<VALUE>``.  Rust is the worked example:
 
 .. code-block:: python
 
@@ -145,298 +144,114 @@ This emits ``serde_json::json!(...)`` expressions, relaxes Rust's
 homogeneous ``Vec<T>`` / ``HashMap<K, V>`` checks, and requires dict keys
 to be strings so they remain valid JSON object keys.
 
-Crystal exposes the same option through its standard-library
-``JSON::Any``:
-
-.. code-block:: python
-
-   """Render Crystal data as JSON::Any."""
-
-   from literalizer import InputFormat, NewVariable, literalize
-   from literalizer.languages import Crystal
-
-   result = literalize(
-       source='{"id": 1, "tags": ["red", 2]}',
-       input_format=InputFormat.JSON,
-       language=Crystal(json_type=Crystal.json_types.JSON_ANY),
-       variable_form=NewVariable(name="payload"),
-   )
-
-The rendered literal is a JSON document wrapped in ``JSON.parse(%(...))``,
-parsed at runtime into a ``JSON::Any``.  The mode relaxes Crystal's
-homogeneous ``Hash(K, V)`` and ``Array(T)`` checks, validates that dict
-keys are strings, and rejects characters that would break the
-``%(...)`` percent literal (``\\``, ``"``, ``(``, ``)``, and ``#{``)
-or overflow JSON's signed 64-bit integer range.
-
-Java exposes the same option through Jackson's ``JsonNode``:
-
-.. code-block:: python
-
-   """Render Java data as a Jackson JsonNode."""
-
-   from literalizer import InputFormat, NewVariable, literalize
-   from literalizer.languages import Java
-
-   result = literalize(
-       source='{"id": 1, "tags": ["red", 2]}',
-       input_format=InputFormat.JSON,
-       language=Java(json_type=Java.json_types.JACKSON_JSON_NODE),
-       variable_form=NewVariable(name="payload"),
-   )
-
-This emits ``new ObjectMapper().readTree("...")`` so the rendered
-binding has the static type ``com.fasterxml.jackson.databind.JsonNode``
-and can hold the heterogeneous values that Java's narrow ``List`` /
-``Map`` types reject.  Dict keys must be strings, and the
-``RECORD`` ``heterogeneous_strategy`` is rejected because the two
-rendering modes cannot be combined.
-
-Kotlin exposes the same option through the ``JsonElement`` type from
-``kotlinx.serialization.json``:
-
-.. code-block:: python
-
-   """Render Kotlin data as a JsonElement."""
-
-   from literalizer import InputFormat, NewVariable, literalize
-   from literalizer.languages import Kotlin
-
-   result = literalize(
-       source='{"id": 1, "tags": ["red", 2]}',
-       input_format=InputFormat.JSON,
-       language=Kotlin(json_type=Kotlin.json_types.KOTLINX_JSON_ELEMENT),
-       variable_form=NewVariable(name="payload"),
-   )
-
-This emits ``Json.parseToJsonElement("...")`` so the rendered binding
-has the static type ``kotlinx.serialization.json.JsonElement`` and can
-hold the heterogeneous values that Kotlin's narrow ``List`` / ``Map``
-types reject.  Dict keys must be strings, and the ``RECORD`` and
-``TUPLE`` ``heterogeneous_strategy`` options are rejected because the
-two rendering modes cannot be combined.
-
-Scala exposes the same option for Circe's :class:`io.circe.Json`:
-
-.. code-block:: python
-
-   """Render Scala data as a Circe Json value."""
-
-   from literalizer import InputFormat, NewVariable, literalize
-   from literalizer.languages import Scala
-
-   result = literalize(
-       source='{"id": 1, "tags": ["red", 2]}',
-       input_format=InputFormat.JSON,
-       language=Scala(json_type=Scala.json_types.CIRCE),
-       variable_form=NewVariable(name="payload"),
-   )
-
-This emits ``Json.obj(...)`` / ``Json.arr(...)`` factories with
-per-scalar ``Json.fromXxx(...)`` constructors, relaxes Scala's
-homogeneous ``List[T]`` / ``Map[String, T]`` checks, and requires dict
-keys to be strings so they remain valid JSON object keys.
-
-The same option is available for C# through
-``CSharp.json_types.SYSTEM_TEXT_JSON_NODE``:
-
-.. code-block:: python
-
-   """Render C# data as a System.Text.Json.Nodes value tree."""
-
-   from literalizer import InputFormat, NewVariable, literalize
-   from literalizer.languages import CSharp
-
-   result = literalize(
-       source='{"id": 1, "tags": ["red", 2]}',
-       input_format=InputFormat.JSON,
-       language=CSharp(json_type=CSharp.json_types.SYSTEM_TEXT_JSON_NODE),
-       variable_form=NewVariable(name="payload"),
-   )
-
-This emits ``new JsonObject { ... }`` / ``new JsonArray { ... }``
-expressions backed by the built-in ``System.Text.Json.Nodes`` library,
-relaxes C#'s homogeneous ``Dictionary<K, V>`` / typed-array checks, and
-switches date / datetime / time values to ISO 8601 strings so they
-remain valid JSON.  The ``const`` modifier is rejected because the JSON
-constructors and the implicit ``(JsonNode?)`` cast applied to scalars
-are runtime expressions, not C# constant initializers.
-
-F# exposes the same option through
-``FSharp.json_types.SYSTEM_TEXT_JSON_NODE``:
-
-.. code-block:: python
-
-   """Render F# data as a System.Text.Json.Nodes value tree."""
-
-   from literalizer import InputFormat, NewVariable, literalize
-   from literalizer.languages import FSharp
-
-   result = literalize(
-       source='{"id": 1, "tags": ["red", 2]}',
-       input_format=InputFormat.JSON,
-       language=FSharp(json_type=FSharp.json_types.SYSTEM_TEXT_JSON_NODE),
-       variable_form=NewVariable(name="payload"),
-   )
-
-This emits ``JsonObject(dict [ ... ])`` / ``JsonArray([| ... |])``
-expressions wrapping per-scalar ``JsonValue.Create(...)`` constructors,
-widened to ``JsonNode`` so heterogeneous children type-infer uniformly.
-The mode opens ``System.Text.Json.Nodes`` inside the generated module,
-relaxes F#'s homogeneous collection checks, switches dates, datetimes,
-and times to ISO 8601 strings (unless ``datetime_format`` is ``EPOCH``),
-and requires dict keys to be strings so they remain valid JSON object
-keys.
-
-Nim exposes the same option through ``Nim.json_types.JSON_NODE``:
-
-.. code-block:: python
-
-   """Render Nim data using the standard library JSON value type."""
-
-   from literalizer import InputFormat, NewVariable, literalize
-   from literalizer.languages import Nim
-
-   result = literalize(
-       source='{"id": 1, "tags": ["red", 2]}',
-       input_format=InputFormat.JSON,
-       language=Nim(json_type=Nim.json_types.JSON_NODE),
-       variable_form=NewVariable(name="payload"),
-   )
-
-This emits ``%*(...)`` expressions backed by Nim's standard-library
-``json`` module,
-relaxes Nim's homogeneous ``seq`` / ``Table`` checks, and switches date and
-datetime values to ISO 8601 strings so they remain valid JSON.  ``CONST``
-declarations are rejected because ``%*`` is a runtime macro and not a
-constant-expression initializer.
-
-Haskell exposes the same option through the ``Data.Aeson.Value``
-type from the ``aeson`` package:
-
-.. code-block:: python
-
-   """Render Haskell data as a ``Data.Aeson.Value``."""
-
-   from literalizer import InputFormat, NewVariable, literalize
-   from literalizer.languages import Haskell
-
-   result = literalize(
-       source='{"id": 1, "tags": ["red", 2]}',
-       input_format=InputFormat.JSON,
-       language=Haskell(json_type=Haskell.json_types.AESON_VALUE),
-       variable_form=NewVariable(name="payload"),
-   )
-
-This emits an ``[aesonQQ| ... |]`` quasi-quote bracket from
-``Data.Aeson.QQ``, mirroring the ``serde_json::json!`` macro on the
-Rust side, so the rendered binding has the static type
-``Data.Aeson.Value`` instead of Haskell's narrow custom ``Val``
-algebraic type, and can hold the heterogeneous values that ``Val``'s
-closed set of constructors rejects.  Dict keys must be strings so they
-remain valid JSON object keys.
-
-Zig exposes the same option through ``Zig.json_types.STD_JSON_VALUE``:
-
-.. code-block:: python
-
-   """Render Zig data using the standard library JSON value type."""
-
-   from literalizer import InputFormat, NewVariable, literalize
-   from literalizer.languages import Zig
-
-   result = literalize(
-       source='{"id": 1, "tags": ["red", 2]}',
-       input_format=InputFormat.JSON,
-       language=Zig(json_type=Zig.json_types.STD_JSON_VALUE),
-       variable_form=NewVariable(name="payload"),
-   )
-
-This emits ``std.json.parseFromSlice(std.json.Value, allocator, "...",
-.{}) catch unreachable`` expressions whose value flows through a
-``std.heap.ArenaAllocator`` preamble injected into ``pub fn main()``.
-The mode
-relaxes Zig's homogeneous ``ZVal`` checks and folds dates, datetimes,
-times, and bytes into JSON-friendly strings.  Dict keys must be
-strings, and ``heterogeneous_strategy=RECORD`` is rejected because
-``parseFromSlice`` rendering cannot be combined with generated
-``struct`` declarations.
-
-C++ exposes the same option through ``Cpp.json_types.NLOHMANN_JSON``:
-
-.. code-block:: python
-
-   """Render C++ data as nlohmann::json."""
-
-   from literalizer import InputFormat, NewVariable, literalize
-   from literalizer.languages import Cpp
-
-   result = literalize(
-       source='{"id": 1, "tags": ["red", 2]}',
-       input_format=InputFormat.JSON,
-       language=Cpp(json_type=Cpp.json_types.NLOHMANN_JSON),
-       variable_form=NewVariable(name="payload"),
-   )
-
-This emits ``nlohmann::json::parse(R"json(...)json")`` expressions and
-adds the ``#include <nlohmann/json.hpp>`` preamble line so the rendered
-binding has the static type ``nlohmann::json`` instead of C++'s narrow
-``std::vector`` / ``std::map`` / ``std::unordered_map`` collection
-types, and can hold the heterogeneous values that ``std::variant``
-would otherwise be needed for.  Dict keys must be strings so they
-remain valid JSON object keys, and the input must not encode the
-raw-string terminator sequence ``)json"`` (e.g. through a dict key
-ending in ``)json``).
-
-Gleam exposes the same option through
-``Gleam.json_types.GLEAM_JSON_JSON``:
-
-.. code-block:: python
-
-   """Render Gleam data using the gleam_json builder type."""
-
-   from literalizer import InputFormat, NewVariable, literalize
-   from literalizer.languages import Gleam
-
-   result = literalize(
-       source='{"id": 1, "tags": ["red", 2]}',
-       input_format=InputFormat.JSON,
-       language=Gleam(json_type=Gleam.json_types.GLEAM_JSON_JSON),
-       variable_form=NewVariable(name="payload"),
-   )
-
-This emits ``gleam_json`` builder calls such as ``json.int(1)``,
-``json.string("red")``, ``json.preprocessed_array([...])``, and
-``json.object([#("k", v), ...])`` so each binding has the static type
-``gleam/json.Json``, ready to feed straight into ``json.to_string``.
-An ``import gleam/json`` line is added at file scope and the generated
-``GVal`` ADT is dropped.  Dict keys must be strings so they remain
-valid JSON object keys, and non-finite floats are rejected because
-the Erlang target has no expression that evaluates to a non-finite
-float.
-
-OCaml exposes the same option through ``OCaml.json_types.YOJSON_SAFE_T``:
-
-.. code-block:: python
-
-   """Render OCaml data as a ``Yojson.Safe.t`` polymorphic variant."""
-
-   from literalizer import InputFormat, NewVariable, literalize
-   from literalizer.languages import OCaml
-
-   result = literalize(
-       source='{"id": 1, "tags": ["red", 2]}',
-       input_format=InputFormat.JSON,
-       language=OCaml(json_type=OCaml.json_types.YOJSON_SAFE_T),
-       variable_form=NewVariable(name="payload"),
-   )
-
-This emits ``Yojson.Safe.t`` polymorphic-variant literals directly,
-keyed by the standard ``yojson`` tag set (``Bool``, ``Int``,
-``Float``, ``String``, ``Null``, ``List``, ``Assoc``, ``Intlit``), so
-the rendered binding has the static type ``Yojson.Safe.t`` instead of
-OCaml's generated ``val_t`` algebraic type, and the ``type val_t = ...``
-preamble drops out entirely:
+Every mode requires dict keys to be strings for the same reason.  The
+remaining languages differ only in the emitted form and a few extra
+constraints:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 12 22 30 36
+
+   * - Language
+     - ``json_type`` value
+     - Emitted form
+     - Notable constraints
+   * - Crystal
+     - ``JSON_ANY``
+     - ``JSON.parse(%(...))`` yielding ``JSON::Any``
+     - Rejects characters that break the ``%(...)`` literal (``\``, ``"``,
+       ``(``, ``)``, ``#{``); rejects integers overflowing signed 64-bit.
+   * - Java
+     - ``JACKSON_JSON_NODE``
+     - ``new ObjectMapper().readTree("...")`` yielding ``JsonNode``
+     - ``RECORD`` ``heterogeneous_strategy`` rejected.
+   * - Kotlin
+     - ``KOTLINX_JSON_ELEMENT``
+     - ``Json.parseToJsonElement("...")`` yielding ``JsonElement``
+     - ``RECORD`` and ``TUPLE`` ``heterogeneous_strategy`` options rejected.
+   * - Scala
+     - ``CIRCE``
+     - ``Json.obj(...)`` / ``Json.arr(...)`` with ``Json.fromXxx(...)``
+       scalars yielding ``io.circe.Json``
+     - None beyond string keys.
+   * - C#
+     - ``SYSTEM_TEXT_JSON_NODE``
+     - ``new JsonObject { ... }`` / ``new JsonArray { ... }`` backed by
+       ``System.Text.Json.Nodes``
+     - Dates / datetimes / times become ISO 8601 strings; the ``const``
+       modifier is rejected (the constructors are runtime expressions).
+   * - F#
+     - ``SYSTEM_TEXT_JSON_NODE``
+     - ``JsonObject(dict [ ... ])`` / ``JsonArray([| ... |])`` with
+       ``JsonValue.Create(...)`` scalars
+     - Dates / datetimes / times become ISO 8601 strings unless
+       ``datetime_format`` is ``EPOCH``.
+   * - Nim
+     - ``JSON_NODE``
+     - ``%*(...)`` backed by the standard-library ``json`` module
+     - Dates / datetimes become ISO 8601 strings; ``CONST`` is rejected
+       (``%*`` is a runtime macro).
+   * - Haskell
+     - ``AESON_VALUE``
+     - ``[aesonQQ| ... |]`` quasi-quote yielding ``Data.Aeson.Value``
+     - None beyond string keys.
+   * - Zig
+     - ``STD_JSON_VALUE``
+     - ``std.json.parseFromSlice(std.json.Value, allocator, "...", .{})
+       catch unreachable`` with an injected ``std.heap.ArenaAllocator``
+       preamble
+     - Dates / datetimes / times / bytes fold into strings; ``RECORD`` is
+       rejected.
+   * - C++
+     - ``NLOHMANN_JSON``
+     - ``nlohmann::json::parse(R"json(...)json")`` plus an
+       ``#include <nlohmann/json.hpp>`` preamble line
+     - Input must not encode the raw-string terminator ``)json"``.
+   * - Gleam
+     - ``GLEAM_JSON_JSON``
+     - ``json.int`` / ``json.string`` / ``json.preprocessed_array`` /
+       ``json.object`` builders yielding ``gleam/json.Json``
+     - Adds an ``import gleam/json`` line and drops the ``GVal`` ADT;
+       non-finite floats rejected (the Erlang target cannot express them).
+   * - Elm
+     - ``JSON_ENCODE_VALUE``
+     - ``Json.Encode.int`` / ``string`` / ``list identity`` / ``object``
+       calls yielding ``Json.Encode.Value``
+     - Adds an ``import Json.Encode`` line in place of the per-fixture
+       ``Val`` ADT.
+   * - PureScript
+     - ``ARGONAUT_JSON``
+     - ``fromRight jsonNull (jsonParser "...")`` yielding
+       ``Data.Argonaut.Core.Json``
+     - Special floats (``NaN``, ``+Infinity``, ``-Infinity``) rejected.
+   * - Scheme
+     - ``GUILE_JSON``
+     - Association lists ``(list (cons "k" v) ...)``, vectors
+       ``(vector v ...)``, and the symbol ``'null``, ready for
+       ``scm->json``
+     - Resolves the default mode's object/array ambiguity; special floats
+       (``NaN``, ``+inf.0``, ``-inf.0``) rejected.
+   * - Erlang
+     - ``OTP_JSON``
+     - UTF-8 binary literals (``<<"..."/utf8>>``) for the built-in
+       ``json`` module; null as the atom ``null``; sets as JSON arrays
+     - Requires the ``OTP_27`` built-in ``json:encode/1``.
+   * - Odin
+     - ``JSON_VALUE``
+     - JSON text parsed at runtime by a package-scope ``_json_parse``
+       helper (over ``core:encoding/json.parse_string``) yielding
+       ``json.Value``
+     - Dates / datetimes / times / bytes fold into strings; ``RECORD`` is
+       rejected.
+
+Two cases are unusual enough to keep as prose.
+
+OCaml's ``YOJSON_SAFE_T`` mode emits ``Yojson.Safe.t`` polymorphic-variant
+literals directly, keyed by the standard ``yojson`` tag set (``Bool``,
+``Int``, ``Float``, ``String``, ``Null``, ``List``, ``Assoc``,
+``Intlit``), so the rendered binding has the static type ``Yojson.Safe.t``
+instead of OCaml's generated ``val_t`` algebraic type, and the
+``type val_t = ...`` preamble drops out entirely:
 
 .. code-block:: ocaml
 
@@ -447,153 +262,8 @@ preamble drops out entirely:
 
 Dates, datetimes, times, and bytes fold into JSON-friendly strings;
 integers that exceed OCaml's native ``int`` range route through the
-``Intlit`` arbitrary-precision escape hatch (a string-tagged JSON
-number) instead of raising.  Dict keys must be strings so they remain
-valid JSON object keys.
-
-Elm exposes the same option through
-``Elm.json_types.JSON_ENCODE_VALUE``:
-
-.. code-block:: python
-
-   """Render Elm data as a Json.Encode.Value."""
-
-   from literalizer import InputFormat, NewVariable, literalize
-   from literalizer.languages import Elm
-
-   result = literalize(
-       source='{"id": 1, "tags": ["red", 2]}',
-       input_format=InputFormat.JSON,
-       language=Elm(json_type=Elm.json_types.JSON_ENCODE_VALUE),
-       variable_form=NewVariable(name="payload"),
-   )
-
-This emits idiomatic ``elm/json`` ``Json.Encode.bool``,
-``Json.Encode.int``, ``Json.Encode.string``,
-``Json.Encode.list identity [ ... ]``, and
-``Json.Encode.object [ ( "k", ... ) ]`` calls and adds an
-``import Json.Encode`` line.  The rendered binding has the static type
-``Json.Encode.Value`` rather than Elm's narrow per-fixture ``Val`` ADT,
-so no walker is needed before ``Json.Encode.encode 0`` and
-heterogeneous collections are accepted.  Dict keys must be strings so
-they remain valid JSON object keys.
-
-PureScript exposes the same option through
-``PureScript.json_types.ARGONAUT_JSON``:
-
-.. code-block:: python
-
-   """Render PureScript data as Argonaut Json."""
-
-   from literalizer import InputFormat, NewVariable, literalize
-   from literalizer.languages import PureScript
-
-   result = literalize(
-       source='{"id": 1, "tags": ["red", 2]}',
-       input_format=InputFormat.JSON,
-       language=PureScript(
-           json_type=PureScript.json_types.ARGONAUT_JSON,
-       ),
-       variable_form=NewVariable(name="payload"),
-   )
-
-This emits a ``fromRight jsonNull (jsonParser "...")`` expression that
-parses the embedded JSON document at runtime, so the rendered binding
-has the static type ``Data.Argonaut.Core.Json`` instead of PureScript's
-narrow custom ``Val`` algebraic type, and can hold the heterogeneous
-values that ``Val``'s closed set of constructors rejects.  Dict keys
-must be strings so they remain valid JSON object keys, and special
-floats (``NaN``, ``+Infinity``, ``-Infinity``) are rejected because
-JSON has no syntax for them.
-
-Scheme exposes the same option through
-``Scheme.json_types.GUILE_JSON``:
-
-.. code-block:: python
-
-   """Render Scheme data for the ``scm->json`` writer in guile-json."""
-
-   from literalizer import InputFormat, NewVariable, literalize
-   from literalizer.languages import Scheme
-
-   result = literalize(
-       source='{"id": 1, "tags": ["red", 2]}',
-       input_format=InputFormat.JSON,
-       language=Scheme(
-           json_type=Scheme.json_types.GUILE_JSON,
-       ),
-       variable_form=NewVariable(name="my-data"),
-   )
-
-This renders objects as Scheme association lists
-(``(list (cons "k" v) ...)``), arrays
-as vectors (``(vector v ...)``), and null as the symbol ``'null`` so
-the binding can be handed directly to ``(scm->json my-data)`` from the
-guile-json ``(json)`` module without an intermediate shape walker.
-The default Scheme rendering folds both objects and arrays into a
-flat ``(list ...)`` form, which makes ``{}`` indistinguishable from
-``[]`` and ``{"a": 1}`` indistinguishable from ``["a", 1]``; the
-``GUILE_JSON`` mode resolves that ambiguity at the source.  Dict keys
-must be strings so they remain valid JSON object keys, and special
-floats (``NaN``, ``+inf.0``, ``-inf.0``) are rejected because JSON
-has no syntax for them.
-
-Erlang exposes the same option through
-``Erlang.json_types.OTP_JSON``:
-
-.. code-block:: python
-
-   """Render Erlang data for Erlang's built-in json module."""
-
-   from literalizer import InputFormat, NewVariable, literalize
-   from literalizer.languages import Erlang
-
-   result = literalize(
-       source='{"id": 1, "tags": ["red", 2]}',
-       input_format=InputFormat.JSON,
-       language=Erlang(json_type=Erlang.json_types.OTP_JSON),
-       variable_form=NewVariable(name="payload"),
-   )
-
-This emits string values, dict keys, ISO 8601 dates / datetimes /
-times, and base64-encoded bytes as UTF-8 binary literals
-(``<<"..."/utf8>>``) rather than Erlang's default ``"..."`` string
-form (a list of code points), since Erlang's ``json:encode/1``
-(available since ``OTP_27``) rejects the list form as a map key and
-emits list-form string values as arrays of integers.  Null renders
-as the bare atom ``null`` (rather than ``undefined``), and sets
-render as JSON arrays.  Dict keys must be strings so they remain
-valid JSON object keys.
-
-Odin exposes the same option through ``Odin.json_types.JSON_VALUE``:
-
-.. code-block:: python
-
-   """Render Odin data as a ``json.Value`` sum-type tree."""
-
-   from literalizer import InputFormat, NewVariable, literalize
-   from literalizer.languages import Odin
-
-   result = literalize(
-       source='{"id": 1, "tags": ["red", 2]}',
-       input_format=InputFormat.JSON,
-       language=Odin(json_type=Odin.json_types.JSON_VALUE),
-       variable_form=NewVariable(name="payload"),
-   )
-
-This emits the literalized document as one JSON-text string parsed at
-runtime by a tiny package-scope ``_json_parse`` helper that wraps
-``core:encoding/json.parse_string`` (with ``parse_integers=true`` so
-integer literals parse to ``Integer`` rather than ``Float``).
-The rendered binding therefore has the static type ``json.Value``
-instead of Odin's default ``map[string]any`` / ``[dynamic]any``
-shape, so the value flows directly through ``json.marshal`` (which
-rejects the ``any``-typed containers) and heterogeneous collections
-no longer raise.  Dates, datetimes, times, and bytes fold into
-JSON-friendly strings.  Dict keys must be strings so they remain
-valid JSON object keys, and ``heterogeneous_strategy=RECORD`` is
-rejected because the generated ``struct`` declarations cannot coexist
-with the single-call parsed value.
+``Intlit`` arbitrary-precision escape hatch (a string-tagged JSON number)
+instead of raising.
 
 D's polarity is reversed from the others: its default already renders
 every value through ``std.json.JSONValue``, so the ``json_type``

--- a/newsfragments/2794.change
+++ b/newsfragments/2794.change
@@ -1,0 +1,1 @@
+Collapsed the repetitive per-language "JSON value types" documentation section into a single lookup table, keeping prose only for the unusual OCaml and D cases.


### PR DESCRIPTION
Resolves #2794. The "JSON value types" section of `docs/source/languages.rst` was a ~500-line wall of near-identical per-language sub-sections, exhausting to read and hard to use as a lookup. This collapses the ~16 repetitive sub-sections into a single `list-table` (language / `json_type` value / emitted form / notable constraints), keeping the Rust `SERDE_JSON_VALUE` worked example and the universal string-key requirement stated once. Prose is retained only for the genuinely unusual OCaml (`Intlit` escape hatch) and D (reversed polarity / `json_type=None`) cases. The section shrinks from ~510 lines to ~180; HTML and spelling builds pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only restructuring in RST and a changelog fragment; no runtime or API behavior changes.
> 
> **Overview**
> Refactors the **JSON value types** section in `docs/source/languages.rst` from many near-duplicate per-language subsections into one **lookup table** (language, `json_type` enum, emitted form, notable constraints).
> 
> The **Rust** `SERDE_JSON_VALUE` example and the shared **string dict keys** requirement stay up front; **OCaml** (`YOJSON_SAFE_T` / `Intlit`) and **D** (inverted `json_type` polarity) remain as short prose with code samples. A **newsfragment** records the doc change for #2794.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6a9645fb7439d7cc1a6e9505ee0dcfb002688e02. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->