### PR TITLE
Harden run_cobol_roundtrip.py string surgery against generated-program drift

### DIFF
--- a/.github/scripts/run_cobol_roundtrip.py
+++ b/.github/scripts/run_cobol_roundtrip.py
@@ -66,6 +66,12 @@ _EXCLUDED_KEYS = ("biginteger", "float_large_exponent")
 # document root).
 _DATA_NAME = _VAR_NAME.upper().replace("_", "-")
 
+# The PROCEDURE DIVISION indent the backend emits.  Derived rather than
+# hard-coded as ``"    "`` so a future ``Cobol.indent`` change relocates
+# the ``STOP RUN`` anchor and the print statements together instead of
+# silently de-syncing.
+_INDENT = Cobol().indent
+
 # Extra WORKING-STORAGE items the print step needs: the pointer
 # ``cJSON_PrintUnformatted`` returns, its ``strlen`` (so the exact JSON
 # bytes are displayed without the trailing spaces of a fixed-width PIC),
@@ -77,12 +83,32 @@ _PRINT_STORAGE = (
 )
 
 _PRINT_STATEMENTS = (
-    '    CALL "cJSON_PrintUnformatted" USING BY VALUE '
+    f'{_INDENT}CALL "cJSON_PrintUnformatted" USING BY VALUE '
     f"{_DATA_NAME} RETURNING JSON-PTR.\n"
-    "    SET ADDRESS OF JSON-OUT TO JSON-PTR.\n"
-    '    CALL "strlen" USING BY VALUE JSON-PTR RETURNING JSON-LEN.\n'
-    "    DISPLAY JSON-OUT(1:JSON-LEN).\n"
+    f"{_INDENT}SET ADDRESS OF JSON-OUT TO JSON-PTR.\n"
+    f'{_INDENT}CALL "strlen" USING BY VALUE JSON-PTR RETURNING JSON-LEN.\n'
+    f"{_INDENT}DISPLAY JSON-OUT(1:JSON-LEN).\n"
 )
+
+
+def _splice_once(*, program: str, anchor: str, replacement: str) -> str:
+    """Return *program* with its sole occurrence of *anchor* replaced by
+    *replacement*.
+
+    Raise :class:`RuntimeError` naming the missing anchor if it does not
+    occur exactly once, so a future change to the generated program's
+    textual shape fails loudly here rather than as a confusing
+    downstream compile / empty-output error.
+    """
+    count = program.count(anchor)
+    if count != 1:
+        msg = (
+            f"Expected exactly one occurrence of anchor {anchor!r} in the "
+            f"generated COBOL program to splice the print step into, but "
+            f"found {count}; the backend's output shape has drifted."
+        )
+        raise RuntimeError(msg)
+    return program.replace(anchor, replacement, 1)
 
 
 def _build_program(*, json_text: str) -> str:
@@ -102,13 +128,16 @@ def _build_program(*, json_text: str) -> str:
         variable_form=literalizer.NewVariable(name=_VAR_NAME),
         wrap_in_file=True,
     )
-    program = result.code.replace(
-        "WORKING-STORAGE SECTION.\n",
-        f"WORKING-STORAGE SECTION.\n{_PRINT_STORAGE}",
-        1,
-    ).replace(
-        "    STOP RUN.",
-        f"{_PRINT_STATEMENTS}    STOP RUN.",
+    stop_run_anchor = f"{_INDENT}STOP RUN."
+    with_storage = _splice_once(
+        program=result.code,
+        anchor="WORKING-STORAGE SECTION.\n",
+        replacement=f"WORKING-STORAGE SECTION.\n{_PRINT_STORAGE}",
+    )
+    program = _splice_once(
+        program=with_storage,
+        anchor=stop_run_anchor,
+        replacement=f"{_PRINT_STATEMENTS}{stop_run_anchor}",
     )
     return f"{program}\n"
 


### PR DESCRIPTION
Follow-up to #2790 / #2801. Closes #2806.

`Cobol(json_type=CJSON)` renders a value as a complete two-division program, and `run_cobol_roundtrip.py` string-surgically injects the print step into the finished `wrap_in_file=True` output. Today that surgery hard-codes a 4-space indent in both `_PRINT_STATEMENTS` and the `"    STOP RUN."` anchor, and a silently-missed `.replace` surfaces only as a confusing downstream compile / empty-output error.

This PR keeps the pragmatic full-program-surgery approach but makes drift fail loudly and locally:

- **Derive the indent** from `Cobol().indent` (new `_INDENT`) instead of hard-coding `"    "`, so a future `Cobol.indent` change relocates the `STOP RUN` anchor and the print statements together.
- **Guard each replacement** via a new `_splice_once` helper that asserts the anchor occurs exactly once and otherwise raises a clear `RuntimeError` naming the missing anchor (`RuntimeError`, not `assert`, per the no-asserts-in-prod convention).

The deeper fix (composing the value into a caller-controlled template instead of patching the finished program) remains the separately-tracked architectural follow-up.

## Verification
- Program generation: both splices land, exactly one `STOP RUN.`, and the guard raises on a missing anchor.
- Full round-trip run locally (with `-L/opt/homebrew/lib` for the local cjson link path): exit 0, `Cobol round-trip OK`.
- `ruff check` + `ruff format --check` clean; all pre-commit hooks pass.

No newsfragment: this is internal hardening of a CI round-trip helper with no user-facing behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal CI helper hardening only; no user-facing or production runtime behavior change.
> 
> **Overview**
> Hardens the COBOL CI round-trip helper so **string surgery on generated programs fails fast** instead of breaking obscurely at compile or with empty output.
> 
> **Indent** for the injected print `CALL`s and the `STOP RUN.` splice anchor now comes from **`Cobol().indent`** (`_INDENT`), so a backend indent change keeps the anchor and new statements aligned.
> 
> **Splicing** is centralized in **`_splice_once`**, which requires each anchor to appear **exactly once** and otherwise raises a **`RuntimeError`** that names the anchor and drift; `_build_program` uses it for WORKING-STORAGE and the stop-run injection instead of blind `.replace` calls.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b459ea6978996841d66f3bce82e3e35eafc2db2f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->