### PR TITLE
Docs: add json_type vs heterogeneous_strategy guidance and cross-links

### DIFF
--- a/docs/source/heterogeneous-strategies.rst
+++ b/docs/source/heterogeneous-strategies.rst
@@ -210,6 +210,37 @@ raises :class:`~literalizer.exceptions.TupleArityNotRepresentableError`
 otherwise); :class:`~literalizer.Rust` and :class:`~literalizer.Scala`
 impose no length limit.
 
+Which should I use? Heterogeneous strategies vs. JSON value types
+-----------------------------------------------------------------
+
+A heterogeneous strategy is not the only way to render mixed-type data.
+Several languages also expose a ``json_type`` constructor argument that
+renders the whole value through a single runtime JSON value type (for
+example ``Rust.json_types.SERDE_JSON_VALUE`` yielding
+``serde_json::Value``).  Both features accept input such as
+``[1, "two", 3.0]`` that the language's narrow collection type cannot
+hold, so the same data often qualifies for either one.  They differ in
+the type of the rendered value:
+
+* A heterogeneous strategy keeps the result **statically typed**.  The
+  generated enum, struct, or tuple preserves each value's original type,
+  and the rendered collection stays a normal typed collection of that
+  wrapper.  Reach for this when the surrounding code is statically typed
+  and you want the compiler to keep tracking the element types, or when
+  the data is conceptually a record (use ``RECORD``).
+* ``json_type`` renders the value as **one runtime JSON value type**
+  (``serde_json::Value``, ``JsonNode``, ``JSON::Any``, and so on).  The
+  static type is uniform and the element types are recovered at runtime.
+  Reach for this when the value is genuinely arbitrary JSON, when you
+  already pass it to a JSON library, or when synthesizing a typed wrapper
+  per shape would be more structure than the data deserves.
+
+The two are mutually exclusive for a given render, and some languages
+reject specific combinations (for instance Java, Kotlin, Zig, and Odin
+reject ``RECORD`` while in their ``json_type`` mode).  See
+:ref:`json-value-types` for every ``json_type`` value, its emitted form,
+and the per-language constraints.
+
 Per-language support matrix
 ---------------------------
 
@@ -277,6 +308,9 @@ Rust, Go, Java, Kotlin, and Scala additionally accept
 declaration name; see each language's reference entry.
 
 .. seealso::
+
+   :ref:`json-value-types` for the runtime JSON value type alternative
+   to a statically typed strategy.
 
    :ref:`languages` for every language class and its other format
    options.

--- a/docs/source/languages.rst
+++ b/docs/source/languages.rst
@@ -118,13 +118,22 @@ constructor argument controls the outcome.  Every language defaults to
 ``RECORD``.  See :ref:`heterogeneous-strategies` for the strategies,
 worked examples, and the per-language support matrix.
 
+.. _json-value-types:
+
 JSON value types
 ----------------
 
 Some languages also have a single runtime JSON value type that is a better
 fit than native narrow collection types.  These languages support this
 through the ``json_type`` constructor argument, accessed as
-``<Language>.json_types.<VALUE>``.  Rust is the worked example:
+``<Language>.json_types.<VALUE>``.
+
+.. seealso::
+
+   :ref:`heterogeneous-strategies` for the statically typed alternative,
+   and its "Which should I use?" note comparing the two approaches.
+
+Rust is the worked example:
 
 .. code-block:: python
 

--- a/newsfragments/2795.change
+++ b/newsfragments/2795.change
@@ -1,0 +1,1 @@
+Document when to choose a ``heterogeneous_strategy`` versus a ``json_type`` for mixed-type data: the heterogeneous strategies page now carries a "Which should I use?" note contrasting the statically typed wrappers with the single runtime JSON value type, and the two documentation sections cross-link each other.


### PR DESCRIPTION
Resolves #2795 by documenting when to choose a `heterogeneous_strategy` versus a `json_type` for mixed-type data. The heterogeneous strategies page gains a "Which should I use?" note contrasting the statically typed wrappers (generated enum/struct/tuple that preserve element types) with the single runtime JSON value type (`serde_json::Value`, `JsonNode`, and so on), including the note that some languages reject `RECORD` while in `json_type` mode. Bidirectional `.. seealso::` cross-links now connect the heterogeneous strategies page and the JSON value types section, which gains a `json-value-types` label. A towncrier `newsfragments/2795.change` entry records the docs change. Verified locally with the project's `sphinx-build -M spelling`, `-M html -W`, and `sphinx-lint` gates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or API behavior impact.
> 
> **Overview**
> Adds documentation to help users choose between **`heterogeneous_strategy`** and **`json_type`** when literalizing mixed-type data.
> 
> The heterogeneous strategies page now includes a **"Which should I use?"** section that contrasts **statically typed** wrappers (enums, records, tuples) with a **single runtime JSON value type**, notes they are mutually exclusive per render, and points to language-specific **`RECORD` + `json_type`** restrictions. The languages page gains a **`json-value-types`** anchor and bidirectional **`.. seealso::`** links between the two topics. A towncrier entry records the change for issue **#2795**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c93b704ac52e41984cda5e793019de13f3dfd85b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->