### PR TITLE
Docs: drop custom-language sketch that imported private modules

### DIFF
--- a/docs/source/languages.rst
+++ b/docs/source/languages.rst
@@ -401,62 +401,8 @@ Custom language implementations
 -------------------------------
 
 To support a language that is not built in, create a class that satisfies
-the :class:`~literalizer.Language` protocol.
-Use ``metaclass=LanguageCls`` and define the required nested enum classes
-and attributes:
-
-This sketch is intentionally incomplete; a complete language defines all
-of the protocol's nested enum classes and attributes.
-
-.. code-block:: python
-
-   """Sketch of a custom language."""
-
-   import enum
-
-   from literalizer._formatters.collection_openers import fixed_open
-   from literalizer._formatters.format_entries import passthrough_sequence_entry
-   from literalizer._language import (
-       LanguageCls,
-       SequenceFormatConfig,
-       no_pygments_name,
-   )
-
-
-   class MyLanguage(metaclass=LanguageCls):
-       """Sketch only; a complete language defines many more nested enums."""
-
-       extension = ".my"
-       pygments_name = no_pygments_name
-
-       class SequenceFormats(enum.Enum):
-           """Available sequence wrappers."""
-
-           LIST = SequenceFormatConfig(
-               sequence_open=fixed_open(open_str="["),
-               close="]",
-               supports_heterogeneity=True,
-               single_element_trailing_comma=False,
-               supports_trailing_comma=True,
-               empty_sequence="[]",
-               preamble_lines=(),
-               format_entry=passthrough_sequence_entry,
-               typed_opener_fallback=None,
-               uses_typed_literal_for_scalars=False,
-               requires_uniform_record_shapes=False,
-               declared_type=None,
-               narrowed_empty_form=None,
-           )
-
-       sequence_formats = SequenceFormats
-
-       # ... define the remaining required enums and attributes ...
-
-
-   list_member = MyLanguage.sequence_formats.LIST
-   assert list_member.name == "LIST"
-   assert MyLanguage.extension == ".my"
-   assert MyLanguage.pygments_name is None
+the :class:`~literalizer.Language` protocol, using ``metaclass=LanguageCls``
+and defining the required nested enum classes and attributes.
 
 When an attribute is part of the :class:`~literalizer.Language` protocol but
 should resolve to ``None``, expose that value through a descriptor or property

--- a/newsfragments/2799.change
+++ b/newsfragments/2799.change
@@ -1,0 +1,1 @@
+Remove the incomplete custom-language sketch from the "Custom language implementations" documentation; it imported private, underscore-prefixed modules.  The section now points readers to the built-in language modules as the worked example.


### PR DESCRIPTION
Closes #2799. The "Custom language implementations" sketch in `docs/source/languages.rst` documented a public extension point but imported names from private, underscore-prefixed modules (`literalizer._formatters`, `literalizer._language`), giving readers no API-stability guarantee. This PR removes the sketch and leaves prose that points readers to the built-in language modules under `literalizer/languages/` as the worked example, plus a towncrier newsfragment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime or API behavior impact.
> 
> **Overview**
> Removes the **incomplete custom-language Python sketch** from the *Custom language implementations* section in `docs/source/languages.rst`. That example imported **private** `literalizer._*` modules, which implied a stable public API for extenders.
> 
> The section is shortened to prose on implementing `:class:`~literalizer.Language` with `LanguageCls`, the existing **class-level `None` / descriptor** note, and a pointer to **built-in modules under `literalizer/languages/`** as the full worked example. A towncrier entry documents the doc-only change (closes #2799).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f99002d0b0007cc2e124fde27e5ba197065cc64f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->