### PR TITLE
Docs: group index toctree by audience; fix contributing prek/pytest

### DIFF
--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -14,7 +14,7 @@ Install Python dependencies in a virtual environment.
 
    $ pip install --editable '.[dev]'
 
-Install ``pre-commit`` hooks:
+Install ``prek`` hooks:
 
 .. code-block:: console
 
@@ -34,11 +34,9 @@ Run lint tools either by committing, or with:
 Running tests
 -------------
 
-Run ``pytest``:
-
 .. code-block:: console
 
-   $ pytest
+   $ uv run --extra dev pytest
 
 Documentation
 -------------

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -142,13 +142,24 @@ Reference
 
 .. toctree::
    :maxdepth: 3
+   :caption: Guides
 
    json-api-use-case
    function-call-use-case
-   api-reference
-   languages
    heterogeneous-strategies
    common-errors
+
+.. toctree::
+   :maxdepth: 3
+   :caption: Reference
+
+   api-reference
+   languages
+
+.. toctree::
+   :maxdepth: 3
+   :caption: Project / Development
+
    release-process
    unreleased
    changelog

--- a/newsfragments/2800.change
+++ b/newsfragments/2800.change
@@ -1,0 +1,1 @@
+Group the documentation index into captioned "Guides", "Reference", and "Project / Development" sections, and correct the contributing guide to reference ``prek`` hooks and the ``uv run --extra dev pytest`` test command.


### PR DESCRIPTION
Resolves #2800.

Groups the documentation index ``toctree`` into captioned "Guides", "Reference", and "Project / Development" sections so the page is organised by audience. Fixes ``contributing.rst`` to refer to ``prek`` hooks (matching the actual ``prek install`` command) and to use ``uv run --extra dev pytest`` as the test command instead of a bare ``pytest``. Adds the towncrier changelog entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and changelog only; no runtime or API behavior changes.
> 
> **Overview**
> The documentation index is reorganized into three captioned **toctree** blocks—**Guides**, **Reference**, and **Project / Development**—so guides, API/language reference, and maintainer docs are grouped separately instead of one flat list.
> 
> The contributing guide now documents **`prek`** (install and lint commands) instead of **pre-commit**, and tells contributors to run tests with **`uv run --extra dev pytest`** instead of a bare **`pytest`**. A towncrier **newsfragments** entry records the doc changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 50d25975f7ab044b351d40adf868b04f4d9f3af7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->