### PR TITLE
Docs: introduce variable_form / NewVariable / ExistingVariable conceptually

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -124,6 +124,89 @@ language:
    #     "port": 8080,
    # }
 
+Binding the result to a variable
+--------------------------------
+
+By default :func:`~literalizer.literalize` renders a bare literal.  Pass
+``variable_form`` to bind that literal to a variable instead, so the
+output is a statement you can drop straight into source.  There are three
+forms, and the difference is visible in languages that distinguish
+declaring a variable from assigning to one:
+
+* :class:`~literalizer.NewVariable` declares a fresh variable (Go's
+  ``config :=``, JavaScript's ``const config =``, Rust's ``let config =``).
+  This is the form nearly every example uses.
+* :class:`~literalizer.ExistingVariable` assigns to a variable declared
+  elsewhere (``config =``), emitting no declaration keyword.
+* :class:`~literalizer.BothVariableForms` emits a declaration *and* a
+  subsequent assignment together, for showing both styles from one
+  source.  It requires ``wrap_in_file=True`` and a language whose
+  declaration style permits reassigning the same name.
+
+The same source, rendered for Go in each form:
+
+.. code-block:: python
+
+   """Contrast the three variable_form choices for one source."""
+
+   from literalizer import (
+       BothVariableForms,
+       ExistingVariable,
+       InputFormat,
+       NewVariable,
+       literalize,
+   )
+   from literalizer.languages import Go
+
+   source = '{"host": "localhost", "port": 8080}'
+
+   new_variable = literalize(
+       source=source,
+       input_format=InputFormat.JSON,
+       language=Go(),
+       variable_form=NewVariable(name="config"),
+   )
+   assert new_variable.code == (
+       'config := map[string]any{\n\t"host": "localhost",\n\t"port": 8080,\n}'
+   )
+
+   existing_variable = literalize(
+       source=source,
+       input_format=InputFormat.JSON,
+       language=Go(),
+       variable_form=ExistingVariable(name="config"),
+   )
+   assert existing_variable.code == (
+       'config = map[string]any{\n\t"host": "localhost",\n\t"port": 8080,\n}'
+   )
+
+   both_forms = literalize(
+       source=source,
+       input_format=InputFormat.JSON,
+       language=Go(),
+       variable_form=BothVariableForms(name="config"),
+       wrap_in_file=True,
+   )
+   assert both_forms.code == (
+       "package main\n"
+       "\n"
+       "func main() {\n"
+       "config := map[string]any{\n"
+       '\t"host": "localhost",\n'
+       '\t"port": 8080,\n'
+       "}\n"
+       "config = map[string]any{\n"
+       '\t"host": "localhost",\n'
+       '\t"port": 8080,\n'
+       "}\n"
+       "_ = config\n"
+       "}"
+   )
+
+For Python, which uses ``config =`` for both declaring and assigning,
+:class:`~literalizer.NewVariable` and :class:`~literalizer.ExistingVariable`
+render identically.
+
 Use cases
 ---------
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -203,9 +203,14 @@ The same source, rendered for Go in each form:
        "}"
    )
 
-For Python, which uses ``config =`` for both declaring and assigning,
-:class:`~literalizer.NewVariable` and :class:`~literalizer.ExistingVariable`
-render identically.
+Whether the two forms differ at all depends on the language.  Python uses
+``config =`` for both declaring and assigning, so with the default
+settings :class:`~literalizer.NewVariable` and
+:class:`~literalizer.ExistingVariable` render identically.  They diverge
+once a feature attaches to the *declaration* specifically: enabling
+``variable_type_hints`` makes :class:`~literalizer.NewVariable` annotate
+the binding (``config: dict[str, str | int] = ...``) while
+:class:`~literalizer.ExistingVariable` stays a bare ``config = ...``.
 
 Use cases
 ---------

--- a/newsfragments/2793.change
+++ b/newsfragments/2793.change
@@ -1,0 +1,1 @@
+Document the ``variable_form`` argument with a "Binding the result to a variable" section that contrasts ``NewVariable``, ``ExistingVariable``, and ``BothVariableForms`` and shows the output each produces.


### PR DESCRIPTION
Closes #2793

## Summary

`variable_form` and its accepted types were used throughout the examples but never introduced conceptually. This adds a "Binding the result to a variable" section to the docs index that:

- explains what `variable_form` does (binds the literalized result to a variable rather than rendering a bare literal),
- contrasts `NewVariable` (declaration), `ExistingVariable` (assignment), and `BothVariableForms` (both combined, requires `wrap_in_file=True`),
- shows the concrete output difference for each, using Go (where declaration `:=` vs assignment `=` is visible),
- notes that in Python the two forms render identically.

## Testing

- `sphinx-build -M html ... -W` passes
- `sphinx-build -M spelling` clean
- doccmd type-check/lint hooks (ruff, pyright, ty, vulture, pylint, interrogate) pass on the new code block
- the example asserts run and pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and changelog fragment only; no runtime or API behavior changes.
> 
> **Overview**
> Adds a **"Binding the result to a variable"** section to the docs landing page (`index.rst`) so `variable_form` is explained before readers hit scattered examples.
> 
> The section describes binding a literalized value to a name via **`NewVariable`**, **`ExistingVariable`**, and **`BothVariableForms`**, with a runnable Go example (including asserts) that shows `:=` vs `=` vs both-in-a-wrapped file. It also notes when Python makes declaration vs assignment output look the same, and when type hints only affect **`NewVariable`**.
> 
> A **`newsfragments/2793.change`** entry records the user-facing doc update for the release notes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3fe977df7e0b7a27d30ec42f7178bb2c386420d5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->