### PR TITLE
Docs: reflow prose to one sentence per line

### DIFF
--- a/docs/source/api-reference.rst
+++ b/docs/source/api-reference.rst
@@ -3,8 +3,7 @@ API Reference
 
 .. currentmodule:: literalizer
 
-Everything documented here is importable directly from the top-level
-``literalizer`` package (exceptions live in :mod:`literalizer.exceptions`).
+Everything documented here is importable directly from the top-level ``literalizer`` package (exceptions live in :mod:`literalizer.exceptions`).
 
 Core functions
 --------------
@@ -25,8 +24,7 @@ Result type
 Variable forms
 --------------
 
-The ``bound_refs`` argument to :func:`literalize` and :func:`literalize_call`
-describes each referenced name as one of these forms.
+The ``bound_refs`` argument to :func:`literalize` and :func:`literalize_call` describes each referenced name as one of these forms.
 
 .. autoclass:: NewVariable
    :members:
@@ -106,8 +104,7 @@ Input formats
 Formatting configuration
 ------------------------
 
-Building blocks used when defining how a language renders collections,
-comments and scalars.
+Building blocks used when defining how a language renders collections, comments and scalars.
 
 .. autoclass:: CollectionLayout
    :members:
@@ -151,8 +148,7 @@ Defining a language
 -------------------
 
 The :class:`Language` protocol describes how a language formats literals.
-Concrete, built-in languages are listed in :doc:`languages`; the members
-below are the contract each one implements.
+Concrete, built-in languages are listed in :doc:`languages`; the members below are the contract each one implements.
 
 .. autoclass:: Language
    :members:

--- a/docs/source/common-errors.rst
+++ b/docs/source/common-errors.rst
@@ -3,22 +3,16 @@
 Common errors and how to resolve them
 =====================================
 
-|project| raises a specific, typed exception whenever it cannot turn your
-data into valid code for the target language, rather than emitting source
-the compiler would reject.  Every exception lives in
-:mod:`literalizer.exceptions`; this page maps each one to its cause and the
-recommended fix.
+|project| raises a specific, typed exception whenever it cannot turn your data into valid code for the target language, rather than emitting source the compiler would reject.
+Every exception lives in :mod:`literalizer.exceptions`; this page maps each one to its cause and the recommended fix.
 
-The tables group the exceptions by the stage at which they are raised.  All
-exceptions are importable from :mod:`literalizer.exceptions`, so a name such
-as ``HeterogeneousScalarCollectionError`` below refers to
-:class:`literalizer.exceptions.HeterogeneousScalarCollectionError`.
+The tables group the exceptions by the stage at which they are raised.
+All exceptions are importable from :mod:`literalizer.exceptions`, so a name such as ``HeterogeneousScalarCollectionError`` below refers to :class:`literalizer.exceptions.HeterogeneousScalarCollectionError`.
 
 Parsing the input
 ------------------
 
-Raised while reading ``source`` in the declared ``input_format``, before any
-language-specific rendering.
+Raised while reading ``source`` in the declared ``input_format``, before any language-specific rendering.
 
 .. list-table::
    :header-rows: 1
@@ -28,13 +22,12 @@ language-specific rendering.
      - Cause
      - How to resolve
    * - :class:`~literalizer.exceptions.ParseError`
-     - Base class for every input-parsing failure.  Catch this to handle any
-       malformed input uniformly.
+     - Base class for every input-parsing failure.
+       Catch this to handle any malformed input uniformly.
      - Validate the source against its declared ``input_format``.
    * - :class:`~literalizer.exceptions.JSONParseError`
      - The ``source`` is not well-formed JSON.
-     - Fix the JSON syntax, or pass the correct ``input_format`` if the data
-       is really JSON5, YAML, or TOML.
+     - Fix the JSON syntax, or pass the correct ``input_format`` if the data is really JSON5, YAML, or TOML.
    * - :class:`~literalizer.exceptions.JSON5ParseError`
      - The ``source`` is not well-formed JSON5.
      - Fix the JSON5 syntax, or choose the matching ``input_format``.
@@ -48,13 +41,9 @@ language-specific rendering.
 Mixed-type collections
 ----------------------
 
-Raised when the data mixes types within one collection but the target
-language requires that collection to be homogeneous.  Each of these
-subclasses :class:`~literalizer.exceptions.HeterogeneousCollectionError`,
-so you can catch the base class to skip any input a strict-typed language
-cannot hold.  The usual fix is to pick a non-default ``heterogeneous_strategy``;
-see :ref:`heterogeneous-strategies` for the full discussion and
-:ref:`json-value-types` for the runtime JSON value alternative.
+Raised when the data mixes types within one collection but the target language requires that collection to be homogeneous.
+Each of these subclasses :class:`~literalizer.exceptions.HeterogeneousCollectionError`, so you can catch the base class to skip any input a strict-typed language cannot hold.
+The usual fix is to pick a non-default ``heterogeneous_strategy``; see :ref:`heterogeneous-strategies` for the full discussion and :ref:`json-value-types` for the runtime JSON value alternative.
 
 .. list-table::
    :header-rows: 1
@@ -67,46 +56,34 @@ see :ref:`heterogeneous-strategies` for the full discussion and
      - Base class for every mixed-type-collection rejection.
      - Catch this to skip any heterogeneous input the language cannot hold.
    * - :class:`~literalizer.exceptions.HeterogeneousScalarCollectionError`
-     - A list mixes scalars of more than one type (e.g. ``[1, "two", 3.0]``)
-       and the language needs a homogeneous element type.
-     - Set ``heterogeneous_strategy`` to ``TAGGED_ENUM`` (or the language's
-       equivalent) to wrap each scalar, or to ``TUPLE`` for a fixed-length
-       array.
+     - A list mixes scalars of more than one type (e.g. ``[1, "two", 3.0]``) and the language needs a homogeneous element type.
+     - Set ``heterogeneous_strategy`` to ``TAGGED_ENUM`` (or the language's equivalent) to wrap each scalar, or to ``TUPLE`` for a fixed-length array.
    * - :class:`~literalizer.exceptions.HeterogeneousSiblingListsError`
      - Sibling sub-lists hold scalars that, combined, span more than one type.
-     - Use a ``TAGGED_ENUM`` strategy, or render the value through a
-       ``json_type``.
+     - Use a ``TAGGED_ENUM`` strategy, or render the value through a ``json_type``.
    * - :class:`~literalizer.exceptions.MixedListValuesError`
      - A list mixes elements from more than one type family.
      - Use a richer ``heterogeneous_strategy`` or a ``json_type``.
    * - :class:`~literalizer.exceptions.MixedDictValuesError`
      - A dict mixes value types that a strict-map language cannot unify.
-     - Use the ``RECORD`` strategy if the dict is conceptually a record, or a
-       ``json_type`` for arbitrary mappings.
+     - Use the ``RECORD`` strategy if the dict is conceptually a record, or a ``json_type`` for arbitrary mappings.
    * - :class:`~literalizer.exceptions.MixedDictKeysError`
      - A dict mixes key types that the language cannot unify.
      - Use a single key type, or render through a ``json_type``.
    * - :class:`~literalizer.exceptions.MixedDictShapesError`
-     - A list holds dicts with different key sets, but the language needs a
-       uniform record shape (e.g. Dhall).
+     - A list holds dicts with different key sets, but the language needs a uniform record shape (e.g. Dhall).
      - Make every dict share the same keys, or use a ``json_type``.
    * - :class:`~literalizer.exceptions.HeterogeneousSetError`
-     - A set mixes scalars of more than one type and the language needs
-       homogeneous set elements.
+     - A set mixes scalars of more than one type and the language needs homogeneous set elements.
      - Use one scalar type, or a richer ``heterogeneous_strategy``.
    * - :class:`~literalizer.exceptions.TupleArityNotRepresentableError`
-     - Under the ``TUPLE`` strategy, a heterogeneous scalar array has a length
-       the language has no native fixed-size tuple for (e.g. Kotlin has only
-       ``Pair`` and ``Triple``).
-     - Shorten the array to a length the language supports, choose a language
-       without the tuple-length cap (Rust, Scala), or switch to a
-       ``TAGGED_ENUM`` strategy.
+     - Under the ``TUPLE`` strategy, a heterogeneous scalar array has a length the language has no native fixed-size tuple for (e.g. Kotlin has only ``Pair`` and ``Triple``).
+     - Shorten the array to a length the language supports, choose a language without the tuple-length cap (Rust, Scala), or switch to a ``TAGGED_ENUM`` strategy.
 
 Values the target language cannot represent
 -------------------------------------------
 
-Raised at the formatting boundary when an individual value has no faithful
-representation in the target language.
+Raised at the formatting boundary when an individual value has no faithful representation in the target language.
 
 .. list-table::
    :header-rows: 1
@@ -116,38 +93,28 @@ representation in the target language.
      - Cause
      - How to resolve
    * - :class:`~literalizer.exceptions.UnrepresentableInputError`
-     - The value's shape cannot be represented, e.g. a non-string dict key for
-       a language whose surface syntax admits only string keys.
-     - Adjust the data to a representable shape, or pick a language that
-       supports it.
+     - The value's shape cannot be represented, e.g. a non-string dict key for a language whose surface syntax admits only string keys.
+     - Adjust the data to a representable shape, or pick a language that supports it.
    * - :class:`~literalizer.exceptions.InvalidDictKeyError`
-     - A dict key cannot be expressed as a label, e.g. an empty-string key or a
-       key with control characters in Dhall backtick labels.
+     - A dict key cannot be expressed as a label, e.g. an empty-string key or a key with control characters in Dhall backtick labels.
      - Remove or rename the offending key.
    * - :class:`~literalizer.exceptions.NullInCollectionError`
-     - A collection contains ``null`` but the chosen collection format cannot
-       hold nulls (e.g. Java's ``List.of()``).
+     - A collection contains ``null`` but the chosen collection format cannot hold nulls (e.g. Java's ``List.of()``).
      - Remove the nulls, or select a collection format that admits them.
    * - :class:`~literalizer.exceptions.UnrepresentableIntegerError`
-     - An integer falls outside the range the language represents natively
-       (e.g. values beyond signed 64-bit on Fortran, Cobol, or PureScript).
-     - Keep integers within range, or target a language with wider or
-       arbitrary-precision integers.
+     - An integer falls outside the range the language represents natively (e.g. values beyond signed 64-bit on Fortran, Cobol, or PureScript).
+     - Keep integers within range, or target a language with wider or arbitrary-precision integers.
    * - :class:`~literalizer.exceptions.UnrepresentableEmptyDictError`
-     - An empty dict is passed to a language whose runtime cannot tell an empty
-       mapping from an empty sequence (Lua, PHP, R).
+     - An empty dict is passed to a language whose runtime cannot tell an empty mapping from an empty sequence (Lua, PHP, R).
      - Drop the empty mapping, or target a language that distinguishes the two.
    * - :class:`~literalizer.exceptions.UnrepresentableSpecialFloatError`
-     - A non-finite float (``inf``, ``-inf``, ``nan``) is passed to a language
-       whose runtime has no such value (e.g. Gleam on the Erlang target).
-     - Replace the non-finite floats with finite values, or pick another
-       language.
+     - A non-finite float (``inf``, ``-inf``, ``nan``) is passed to a language whose runtime has no such value (e.g. Gleam on the Erlang target).
+     - Replace the non-finite floats with finite values, or pick another language.
 
 Identifiers and variable wrapping
 ---------------------------------
 
-Raised when ``variable_form`` or ``ref_case`` asks for output the target
-language cannot produce.
+Raised when ``variable_form`` or ``ref_case`` asks for output the target language cannot produce.
 
 .. list-table::
    :header-rows: 1
@@ -157,30 +124,23 @@ language cannot produce.
      - Cause
      - How to resolve
    * - :class:`~literalizer.exceptions.UnsupportedIdentifierCaseError`
-     - The supplied ``ref_case`` is not in the language's
-       ``supported_ref_cases`` and would not form a legal identifier.
+     - The supplied ``ref_case`` is not in the language's ``supported_ref_cases`` and would not form a legal identifier.
      - Choose a ``ref_case`` from the language's ``supported_ref_cases``.
    * - :class:`~literalizer.exceptions.VariableNameNotSupportedError`
-     - A ``variable_form`` was given for a language that has no variable-name
-       wrapping.
+     - A ``variable_form`` was given for a language that has no variable-name wrapping.
      - Omit ``variable_form`` for that language, or target one that supports it.
    * - :class:`~literalizer.exceptions.WrapInFileWithoutVariableNotSupportedError`
-     - ``wrap_in_file=True`` with ``variable_form=None`` for a language that
-       cannot place a bare value at file scope (most strict-typed compiled
-       languages).
+     - ``wrap_in_file=True`` with ``variable_form=None`` for a language that cannot place a bare value at file scope (most strict-typed compiled languages).
      - Supply a ``variable_form`` so the value becomes a top-level declaration.
    * - :class:`~literalizer.exceptions.InvalidRecordNameError`
-     - ``record_struct_name_prefix`` or a ``record_shape_names`` value is not a
-       valid name, collides with a keyword or another struct name, or clashes
-       with ``heterogeneous_value_enum_name``.
+     - ``record_struct_name_prefix`` or a ``record_shape_names`` value is not a valid name, collides with a keyword or another struct name, or clashes with ``heterogeneous_value_enum_name``.
      - Use distinct, valid PascalCase names that avoid reserved keywords.
 
 Function calls
 --------------
 
-Raised by :func:`~literalizer.literalize_call` and its arguments
-(``parameter_names``, ``call_transform``, ``zip_source``, ``comment_source``,
-``target_function``).  See :doc:`function-call-use-case`.
+Raised by :func:`~literalizer.literalize_call` and its arguments (``parameter_names``, ``call_transform``, ``zip_source``, ``comment_source``, ``target_function``).
+See :doc:`function-call-use-case`.
 
 .. list-table::
    :header-rows: 1
@@ -190,59 +150,46 @@ Raised by :func:`~literalizer.literalize_call` and its arguments
      - Cause
      - How to resolve
    * - :class:`~literalizer.exceptions.CallsNotSupportedByLanguageError`
-     - The target language has no function-call syntax at all (pure data and
-       markup formats such as YAML, TOML, JSON5, Norg).
-     - Use :func:`~literalizer.literalize` instead, or target a programming
-       language.
+     - The target language has no function-call syntax at all (pure data and markup formats such as YAML, TOML, JSON5, Norg).
+     - Use :func:`~literalizer.literalize` instead, or target a programming language.
    * - :class:`~literalizer.exceptions.CallsNotSupportedByToolError`
-     - The language has call syntax, but |project| does not yet render calls
-       for it.
+     - The language has call syntax, but |project| does not yet render calls for it.
      - Target a language whose call rendering is implemented.
    * - :class:`~literalizer.exceptions.PerElementNotListError`
      - ``per_element=True`` but the parsed data is not a list.
      - Pass a list, or drop ``per_element``.
    * - :class:`~literalizer.exceptions.ParameterCountMismatchError`
-     - The number of ``parameter_names`` does not match the argument values in
-       a call row.
+     - The number of ``parameter_names`` does not match the argument values in a call row.
      - Make ``parameter_names`` the same length as each row of values.
    * - :class:`~literalizer.exceptions.CallArgNotSupportedError`
-     - A call argument value cannot be a positional argument, e.g. an inline
-       compound literal in Bash.
-     - Bind the value to a name first, or target a language that accepts the
-       argument inline.
+     - A call argument value cannot be a positional argument, e.g. an inline compound literal in Bash.
+     - Bind the value to a name first, or target a language that accepts the argument inline.
    * - :class:`~literalizer.exceptions.UnsupportedCallShapeError`
-     - The call's structure cannot be represented, e.g. a zero-parameter call
-       in a language that needs at least one operand.
+     - The call's structure cannot be represented, e.g. a zero-parameter call in a language that needs at least one operand.
      - Adjust the call shape, or target a language that supports it.
    * - :class:`~literalizer.exceptions.DottedCallTargetNotSupportedError`
-     - A dotted ``target_function`` was given to a language without dotted call
-       expressions.
+     - A dotted ``target_function`` was given to a language without dotted call expressions.
      - Use a target name without dots, or target a language with dotted calls.
    * - :class:`~literalizer.exceptions.ZipSourceWithoutInputFormatError`
      - ``zip_source`` was supplied without ``zip_input_format``.
      - Pass ``zip_input_format`` alongside ``zip_source``.
    * - :class:`~literalizer.exceptions.ZipValuesWithoutCallTransformError`
-     - ``zip_source`` was supplied without a ``call_transform`` to consume the
-       paired values.
-     - Supply a ``call_transform`` that reads
-       :attr:`~literalizer.CallContext.zipped`, or drop ``zip_source``.
+     - ``zip_source`` was supplied without a ``call_transform`` to consume the paired values.
+     - Supply a ``call_transform`` that reads :attr:`~literalizer.CallContext.zipped`, or drop ``zip_source``.
    * - :class:`~literalizer.exceptions.ZipValuesLengthMismatchError`
-     - ``zip_source`` parsed to a different number of elements than the calls
-       generated.
+     - ``zip_source`` parsed to a different number of elements than the calls generated.
      - Make ``zip_source`` hold one element per generated call.
    * - :class:`~literalizer.exceptions.CommentSourceLengthMismatchError`
      - ``comment_source`` has a different entry count than the calls generated.
      - Provide one comment per generated call.
    * - :class:`~literalizer.exceptions.CommentSourceMultilineError`
-     - A ``comment_source`` entry contains a newline; trailing comments must be
-       single-line.
+     - A ``comment_source`` entry contains a newline; trailing comments must be single-line.
      - Remove the newline, keeping each comment on one line.
 
 Format option combinations
 --------------------------
 
-Raised when otherwise valid options combine into something the language
-cannot emit.
+Raised when otherwise valid options combine into something the language cannot emit.
 
 .. list-table::
    :header-rows: 1
@@ -252,14 +199,11 @@ cannot emit.
      - Cause
      - How to resolve
    * - :class:`~literalizer.exceptions.IncompatibleFormatsError`
-     - Two format options conflict, e.g. Rust ``CONST``/``STATIC`` needs a
-       constant initializer but ``VEC`` produces a non-constant expression.
+     - Two format options conflict, e.g. Rust ``CONST``/``STATIC`` needs a constant initializer but ``VEC`` produces a non-constant expression.
      - Change one of the conflicting options so they agree.
    * - :class:`~literalizer.exceptions.WrapCombinedInFileNotSupportedError`
-     - ``wrap_combined_in_file`` was used with a language that does not support
-       :class:`~literalizer.BothVariableForms`.
-     - Use a single variable form, or target a language that supports the
-       combined form.
+     - ``wrap_combined_in_file`` was used with a language that does not support :class:`~literalizer.BothVariableForms`.
+     - Use a single variable form, or target a language that supports the combined form.
 
 .. seealso::
 
@@ -267,5 +211,4 @@ cannot emit.
 
    :ref:`json-value-types` for the runtime JSON value alternative.
 
-   :doc:`api-reference` for the generated :mod:`literalizer.exceptions`
-   reference.
+   :doc:`api-reference` for the generated :mod:`literalizer.exceptions` reference.

--- a/docs/source/function-call-use-case.rst
+++ b/docs/source/function-call-use-case.rst
@@ -1,19 +1,14 @@
 Rendering function calls
 ========================
 
-If your documentation or test suite needs to show function calls with
-literal arguments across multiple languages, :func:`literalizer.literalize_call`
-generates those calls from a single YAML, JSON, JSON5, or TOML source.
+If your documentation or test suite needs to show function calls with literal arguments across multiple languages, :func:`literalizer.literalize_call` generates those calls from a single YAML, JSON, JSON5, or TOML source.
 
-Each row of a top-level list becomes a separate function call, with
-arguments formatted according to the target language's calling
-convention.
+Each row of a top-level list becomes a separate function call, with arguments formatted according to the target language's calling convention.
 
 Example
 -------
 
-Suppose you want to generate calls to ``throttler.check`` with two
-parameters (``user_id`` and ``ts``) and wrap each call in ``print()``:
+Suppose you want to generate calls to ``throttler.check`` with two parameters (``user_id`` and ``ts``) and wrap each call in ``print()``:
 
 .. code-block:: python
 
@@ -57,11 +52,10 @@ parameters (``user_id`` and ``ts``) and wrap each call in ``print()``:
 Calling conventions
 -------------------
 
-Each language has a calling convention that determines how arguments are
-formatted.  There are three styles:
+Each language has a calling convention that determines how arguments are formatted.
+There are three styles:
 
-**Keyword** (e.g. Python, Swift, Ruby):
-arguments are passed as ``name=value`` pairs.
+**Keyword** (e.g. Python, Swift, Ruby): arguments are passed as ``name=value`` pairs.
 
 .. code-block:: python
 
@@ -79,30 +73,24 @@ arguments are passed as ``name=value`` pairs.
    throttler = Throttler()
    print(throttler.check(user_id="user_1", ts=1000.0))
 
-**Object** (e.g. JavaScript, TypeScript):
-arguments are wrapped in an object literal.
+**Object** (e.g. JavaScript, TypeScript): arguments are wrapped in an object literal.
 
 .. code-block:: javascript
 
    print(throttler.check({ user_id: "user_1", ts: 1000.0 }));
 
-**Positional** (e.g. Rust, Java, C++):
-arguments are passed by position only — parameter names are not included
-in the output.
+**Positional** (e.g. Rust, Java, C++): arguments are passed by position only — parameter names are not included in the output.
 
 .. code-block:: rust
 
    print(throttler.check("user_1", 1000.0));
 
-You do not need to choose a style — it is determined automatically by
-the language you pass to :func:`~literalizer.literalize_call`.
+You do not need to choose a style — it is determined automatically by the language you pass to :func:`~literalizer.literalize_call`.
 
 Constructor targets
 -------------------
 
-To bind the result of a zero-argument constructor call, ask the language
-for its constructor target and pass that to
-:func:`~literalizer.literalize_call` as ``target_function``:
+To bind the result of a zero-argument constructor call, ask the language for its constructor target and pass that to :func:`~literalizer.literalize_call` as ``target_function``:
 
 .. code-block:: python
 
@@ -126,40 +114,24 @@ for its constructor target and pass that to
 
    assert result.code == "let mut p = Playlist::new();"
 
-The default constructor target is ``ClassName``.  Languages with
-different common constructor syntax override it; for example Java and
-JavaScript return ``new ClassName``, Go returns ``NewClassName``, Ruby
-returns ``ClassName.new``, and Rust returns ``ClassName::new``.
+The default constructor target is ``ClassName``.
+Languages with different common constructor syntax override it; for example Java and JavaScript return ``new ClassName``, Go returns ``NewClassName``, Ruby returns ``ClassName.new``, and Rust returns ``ClassName::new``.
 
-For languages whose default call style wraps arguments in an object,
-use the positional call-style option when rendering a no-argument
-constructor so the call is emitted as ``new Playlist()`` rather than
-``new Playlist({})``.
+For languages whose default call style wraps arguments in an object, use the positional call-style option when rendering a no-argument constructor so the call is emitted as ``new Playlist()`` rather than ``new Playlist({})``.
 
 Variable references as arguments
 --------------------------------
 
-An argument can be a **reference to a named variable** instead of an
-inline literal value.  Use a ``{"$ref": "name"}`` marker at the
-argument position and :func:`~literalizer.literalize_call` emits the
-identifier verbatim at that slot.  Other arguments are still rendered
-as literals as usual, so refs and literals can be mixed freely.
+An argument can be a **reference to a named variable** instead of an inline literal value.
+Use a ``{"$ref": "name"}`` marker at the argument position and :func:`~literalizer.literalize_call` emits the identifier verbatim at that slot.
+Other arguments are still rendered as literals as usual, so refs and literals can be mixed freely.
 
-For example, passing the JSON source ``[[{"$ref": "my_var"}, 42]]`` to
-:func:`~literalizer.literalize_call` with ``parameter_names=["data",
-"count"]`` and ``language=Python()`` yields
-``process(data=my_var, count=42)``.
+For example, passing the JSON source ``[[{"$ref": "my_var"}, 42]]`` to :func:`~literalizer.literalize_call` with ``parameter_names=["data", "count"]`` and ``language=Python()`` yields ``process(data=my_var, count=42)``.
 
-This composes with
-:class:`~literalizer.NewVariable`: declare the data once with
-:func:`~literalizer.literalize` and then refer to it from a call rendered
-by :func:`~literalizer.literalize_call`, without repeating the literal
-value at the call site.
+This composes with :class:`~literalizer.NewVariable`: declare the data once with :func:`~literalizer.literalize` and then refer to it from a call rendered by :func:`~literalizer.literalize_call`, without repeating the literal value at the call site.
 
-When the referenced value contains types that affect generated
-declarations or imports, pass those source values via ``ref_values``.
-The call still renders only the identifier, but the referenced value
-participates in preamble inference:
+When the referenced value contains types that affect generated declarations or imports, pass those source values via ``ref_values``.
+The call still renders only the identifier, but the referenced value participates in preamble inference:
 
 .. code-block:: python
 
@@ -185,75 +157,43 @@ participates in preamble inference:
    )
    assert call.declaration_code == "process(myList, 42)"
 
-If a ref name is omitted from ``ref_values``, its marker is ignored for
-preamble inference as before.  ``ref_values`` keys are the names from
-the input data before any ``ref_case`` conversion.
+If a ref name is omitted from ``ref_values``, its marker is ignored for preamble inference as before.
+``ref_values`` keys are the names from the input data before any ``ref_case`` conversion.
 
-By default the identifier is emitted verbatim.  Pass ``ref_case`` to
-:func:`~literalizer.literalize_call` to convert the name to the target
-language's idiomatic case.
+By default the identifier is emitted verbatim.
+Pass ``ref_case`` to :func:`~literalizer.literalize_call` to convert the name to the target language's idiomatic case.
 
 Case conversion
 ~~~~~~~~~~~~~~~
 
-The ``ref_case`` parameter accepts a :class:`~literalizer.IdentifierCase`
-value (``SNAKE``, ``CAMEL``, ``PASCAL``, ``UPPER_SNAKE``, or ``KEBAB``).
+The ``ref_case`` parameter accepts a :class:`~literalizer.IdentifierCase` value (``SNAKE``, ``CAMEL``, ``PASCAL``, ``UPPER_SNAKE``, or ``KEBAB``).
 Each :class:`Language` exposes two related but independent attributes:
 
-* :attr:`~literalizer.Language.supported_ref_cases` -- the cases that
-  produce a syntactically legal identifier in the target language.
-  Passing a case outside this set raises
-  :class:`~literalizer.exceptions.UnsupportedIdentifierCaseError`.
-  Most C-family languages set this to
-  :data:`~literalizer.NON_KEBAB_REF_CASES`, since ``my-var`` is not a
-  legal identifier; Lisp-family languages and other kebab-friendly
-  grammars use :data:`~literalizer.ALL_REF_CASES`.
-* :attr:`~literalizer.Language.identifier_cases` -- the cases that are
-  *idiomatic* for the language, ordered by stylistic preference (the
-  first element is the default).  This list is documentation of style
-  only; it is not used to reject explicit ``ref_case`` choices.  A
-  language may prefer only ``SNAKE`` while still syntactically
-  supporting ``CAMEL``, ``PASCAL``, and ``UPPER_SNAKE``.
+* :attr:`~literalizer.Language.supported_ref_cases` -- the cases that produce a syntactically legal identifier in the target language.
+  Passing a case outside this set raises :class:`~literalizer.exceptions.UnsupportedIdentifierCaseError`.
+  Most C-family languages set this to :data:`~literalizer.NON_KEBAB_REF_CASES`, since ``my-var`` is not a legal identifier; Lisp-family languages and other kebab-friendly grammars use :data:`~literalizer.ALL_REF_CASES`.
+* :attr:`~literalizer.Language.identifier_cases` -- the cases that are *idiomatic* for the language, ordered by stylistic preference (the first element is the default).
+  This list is documentation of style only; it is not used to reject explicit ``ref_case`` choices.
+  A language may prefer only ``SNAKE`` while still syntactically supporting ``CAMEL``, ``PASCAL``, and ``UPPER_SNAKE``.
 
-The same YAML source can drive idiomatic identifiers across multiple
-languages.  For example, the JSON source ``[[{"$ref": "user_obj"}, 42]]``
-with ``parameter_names=["data", "count"]`` produces:
+The same YAML source can drive idiomatic identifiers across multiple languages.
+For example, the JSON source ``[[{"$ref": "user_obj"}, 42]]`` with ``parameter_names=["data", "count"]`` produces:
 
-* ``ref_case=IdentifierCase.SNAKE`` with ``language=Python()`` →
-  ``process(data=user_obj, count=42)``.
-* ``ref_case=IdentifierCase.CAMEL`` with ``language=JavaScript()`` →
-  ``process({ data: userObj, count: 42 });``.
-* ``ref_case=IdentifierCase.PASCAL`` with ``language=Go()`` →
-  ``process(UserObj, 42)``.
+* ``ref_case=IdentifierCase.SNAKE`` with ``language=Python()`` → ``process(data=user_obj, count=42)``.
+* ``ref_case=IdentifierCase.CAMEL`` with ``language=JavaScript()`` → ``process({ data: userObj, count: 42 });``.
+* ``ref_case=IdentifierCase.PASCAL`` with ``language=Go()`` → ``process(UserObj, 42)``.
 
 Composing declarations and calls
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Pairing a :func:`~literalizer.literalize` call (which declares a
-variable) with a :func:`~literalizer.literalize_call` call (which
-references that variable via ``{"$ref": "name"}``) is the natural way
-to render a complete, self-contained source file: declaration first,
-call second.
+Pairing a :func:`~literalizer.literalize` call (which declares a variable) with a :func:`~literalizer.literalize_call` call (which references that variable via ``{"$ref": "name"}``) is the natural way to render a complete, self-contained source file: declaration first, call second.
 
-Each call independently computes its own
-:attr:`~literalizer.LiteralizeResult.preamble` and
-:attr:`~literalizer.LiteralizeResult.body_preamble` from the data it
-sees.  When the two halves see overlapping data — for example, both
-contain integers in a language where integers require a wrapper type
-declaration — concatenating their outputs as-is produces duplicates.
-Strict compilers reject the result (Haskell rejects duplicate ``data``
-declarations; D rejects duplicate ``import`` lines) and a linter flags
-it (``ruff`` and ``pylint`` warn about repeated ``from typing import
-Any`` lines).
+Each call independently computes its own :attr:`~literalizer.LiteralizeResult.preamble` and :attr:`~literalizer.LiteralizeResult.body_preamble` from the data it sees.
+When the two halves see overlapping data — for example, both contain integers in a language where integers require a wrapper type declaration — concatenating their outputs as-is produces duplicates.
+Strict compilers reject the result (Haskell rejects duplicate ``data`` declarations; D rejects duplicate ``import`` lines) and a linter flags it (``ruff`` and ``pylint`` warn about repeated ``from typing import Any`` lines).
 
-Pass the ref values through the ``bound_refs`` argument of
-:func:`~literalizer.literalize_call` (with ``wrap_in_file=True``) and
-it renders the whole file for you: each ref is declared ahead of the
-calls, a no-op stub for the target function is injected, and one
-reconciled preamble is placed in front.  This is the call-side
-counterpart of :func:`~literalizer.literalize`'s own ``bound_refs``
-argument; the returned :attr:`~literalizer.LiteralizeResult.code` is
-the finished file:
+Pass the ref values through the ``bound_refs`` argument of :func:`~literalizer.literalize_call` (with ``wrap_in_file=True``) and it renders the whole file for you: each ref is declared ahead of the calls, a no-op stub for the target function is injected, and one reconciled preamble is placed in front.
+This is the call-side counterpart of :func:`~literalizer.literalize`'s own ``bound_refs`` argument; the returned :attr:`~literalizer.LiteralizeResult.code` is the finished file:
 
 .. code-block:: python
 
@@ -274,32 +214,21 @@ the finished file:
 
    assert composed.code.count("data Val = HInt Integer | HList [Val]") == 1
 
-``bound_refs`` entries double as ``ref_values``, so a name need not be
-repeated in both mappings, and they are emitted in iteration order
-ahead of their first use.
+``bound_refs`` entries double as ``ref_values``, so a name need not be repeated in both mappings, and they are emitted in iteration order ahead of their first use.
 
-Snake case is the recommended authoring convention for ``$ref`` names:
-``pyhumps`` converts ``snake_case`` to every other case without loss.
-Inputs in other conventions are normalized to ``snake_case`` first, so
-``userObj`` or ``UserObj`` also convert correctly, but at the cost of
-losing any preserved acronyms: ``HTTPRequest`` normalizes to
-``http_request`` and converts back to Pascal case as ``HttpRequest``.
+Snake case is the recommended authoring convention for ``$ref`` names: ``pyhumps`` converts ``snake_case`` to every other case without loss.
+Inputs in other conventions are normalized to ``snake_case`` first, so ``userObj`` or ``UserObj`` also convert correctly, but at the cost of losing any preserved acronyms: ``HTTPRequest`` normalizes to ``http_request`` and converts back to Pascal case as ``HttpRequest``.
 
 References inside plain data structures
 ----------------------------------------
 
-``{"$ref": "name"}`` markers also work inside data passed to
-:func:`~literalizer.literalize` -- not just inside call arguments.  This
-is useful when you want to emit a data structure where some values are
-references to variables declared elsewhere rather than inline literals.
+``{"$ref": "name"}`` markers also work inside data passed to :func:`~literalizer.literalize` -- not just inside call arguments.
+This is useful when you want to emit a data structure where some values are references to variables declared elsewhere rather than inline literals.
 
-By default, ref identifiers are emitted verbatim.  Pass ``ref_case`` to
-:func:`~literalizer.literalize` when the identifier should be converted
-before rendering.
+By default, ref identifiers are emitted verbatim.
+Pass ``ref_case`` to :func:`~literalizer.literalize` when the identifier should be converted before rendering.
 
-For example, suppose you have a configuration dict where ``timeout`` and
-``host`` are already declared as named constants and you want to reference
-them rather than repeat the values:
+For example, suppose you have a configuration dict where ``timeout`` and ``host`` are already declared as named constants and you want to reference them rather than repeat the values:
 
 .. code-block:: python
 
@@ -322,24 +251,15 @@ them rather than repeat the values:
        '{\n    "timeout": timeout_secs,\n    "host": default_host,\n}'
    )
 
-The same ``ref_case`` rules apply as for :func:`~literalizer.literalize_call`:
-the identifier is case-converted to the requested convention and any
-language-specific sigil is applied (e.g. ``$timeout_secs`` in PHP).
-Refs can appear at any depth -- nested inside dicts, inside lists, or as
-the top-level value -- and can be mixed freely with ordinary literals in
-the same structure.
+The same ``ref_case`` rules apply as for :func:`~literalizer.literalize_call`: the identifier is case-converted to the requested convention and any language-specific sigil is applied (e.g. ``$timeout_secs`` in PHP).
+Refs can appear at any depth -- nested inside dicts, inside lists, or as the top-level value -- and can be mixed freely with ordinary literals in the same structure.
 
 Pairing each call with a value
 ------------------------------
 
-``call_transform`` receives a :class:`~literalizer.CallContext`, not just
-the call string.  Alongside ``ctx.call`` (the rendered call expression)
-it carries the call's zero-based ``ctx.index``, its input ``ctx.row``,
-and -- when ``zip_source`` is supplied -- ``ctx.zipped``: the matching
-top-level element of a second, equal-length companion source, parsed
-with the same parser as ``source`` and rendered as a language-native
-literal.  This lets you print an expected value beside each call's
-actual return value:
+``call_transform`` receives a :class:`~literalizer.CallContext`, not just the call string.
+Alongside ``ctx.call`` (the rendered call expression) it carries the call's zero-based ``ctx.index``, its input ``ctx.row``, and -- when ``zip_source`` is supplied -- ``ctx.zipped``: the matching top-level element of a second, equal-length companion source, parsed with the same parser as ``source`` and rendered as a language-native literal.
+This lets you print an expected value beside each call's actual return value:
 
 .. code-block:: python
 
@@ -380,27 +300,15 @@ actual return value:
        'catalog.lookup(title="Solaris", year=1961))'
    )
 
-``zip_source`` is parsed with the same parser as ``source``; when
-``per_element`` is ``True`` it must parse to a list whose top-level
-elements pair one-for-one with the generated calls.  It requires
-``zip_input_format`` and a ``call_transform``.  ``call_transform`` is
-only supported for
-languages whose call form is an expression that can be wrapped
-(positional, keyword, or object call style); prefix-, postfix-, and
-command-style languages reject it with
-:class:`~literalizer.exceptions.UnsupportedCallShapeError`.
+``zip_source`` is parsed with the same parser as ``source``; when ``per_element`` is ``True`` it must parse to a list whose top-level elements pair one-for-one with the generated calls.
+It requires ``zip_input_format`` and a ``call_transform``.
+``call_transform`` is only supported for languages whose call form is an expression that can be wrapped (positional, keyword, or object call style); prefix-, postfix-, and command-style languages reject it with :class:`~literalizer.exceptions.UnsupportedCallShapeError`.
 
 Annotating each call with a trailing comment
 --------------------------------------------
 
-A ``call_transform`` only sees the *call expression*, before the
-language's statement terminator is applied, so it cannot append a
-trailing line comment: in C-family languages the terminator would land
-*inside* the comment (``catalog.lookup("Dune", 1965)  // first
-edition;``) and the statement would no longer compile.  ``comment_source``
-solves this by handing the core a sequence of comments -- one per
-generated call, paired positionally -- which it emits **after** the
-statement terminator using the target language's comment syntax:
+A ``call_transform`` only sees the *call expression*, before the language's statement terminator is applied, so it cannot append a trailing line comment: in C-family languages the terminator would land *inside* the comment (``catalog.lookup("Dune", 1965)  // first edition;``) and the statement would no longer compile.
+``comment_source`` solves this by handing the core a sequence of comments -- one per generated call, paired positionally -- which it emits **after** the statement terminator using the target language's comment syntax:
 
 .. code-block:: python
 
@@ -429,26 +337,10 @@ statement terminator using the target language's comment syntax:
        'catalog.lookup("Solaris", 1961);  // translated from Polish'
    )
 
-``comment_source`` is a plain sequence, not a parsed source, so it needs
-neither a ``call_transform`` nor an input format.  Its length must equal
-the number of generated calls (one per top-level element when
-``per_element`` is ``True``, otherwise one) or
-:class:`~literalizer.exceptions.CommentSourceLengthMismatchError` is
-raised; an empty entry emits no comment, and an entry containing a
-newline raises
-:class:`~literalizer.exceptions.CommentSourceMultilineError`.  Languages
-with no line comment fall back to that language's block-comment form
-(``catalog.lookup("Dune", 1965)  (* first edition *)`` in OCaml), which
-is valid on a single line.
+``comment_source`` is a plain sequence, not a parsed source, so it needs neither a ``call_transform`` nor an input format.
+Its length must equal the number of generated calls (one per top-level element when ``per_element`` is ``True``, otherwise one) or :class:`~literalizer.exceptions.CommentSourceLengthMismatchError` is raised; an empty entry emits no comment, and an entry containing a newline raises :class:`~literalizer.exceptions.CommentSourceMultilineError`.
+Languages with no line comment fall back to that language's block-comment form (``catalog.lookup("Dune", 1965)  (* first edition *)`` in OCaml), which is valid on a single line.
 
-A trailing comment is only safe where each generated call is a
-self-contained line.  Languages that assemble the call sequence into a
-single clause, list or expression -- so a separator, terminator or
-closer would follow the call on the same line and the line comment
-would swallow it (Erlang's clause-terminating ``.``, a Jsonnet list
-``,``, a Roc ``dbg ( ... )`` wrapper) -- reject a non-empty
-``comment_source``
-with :class:`~literalizer.exceptions.UnsupportedCallShapeError`.  The
-supported set is exactly the languages whose
-:attr:`~literalizer.Language.supports_standalone_comments_in_wrapped_calls`
-is ``True``.
+A trailing comment is only safe where each generated call is a self-contained line.
+Languages that assemble the call sequence into a single clause, list or expression -- so a separator, terminator or closer would follow the call on the same line and the line comment would swallow it (Erlang's clause-terminating ``.``, a Jsonnet list ``,``, a Roc ``dbg ( ... )`` wrapper) -- reject a non-empty ``comment_source`` with :class:`~literalizer.exceptions.UnsupportedCallShapeError`.
+The supported set is exactly the languages whose :attr:`~literalizer.Language.supports_standalone_comments_in_wrapped_calls` is ``True``.

--- a/docs/source/heterogeneous-strategies.rst
+++ b/docs/source/heterogeneous-strategies.rst
@@ -3,38 +3,24 @@
 Heterogeneous strategies
 ========================
 
-Some target languages can hold a collection whose elements have
-different types; others require every element of a list, or every
-value of a map, to share one static type.  A *heterogeneous strategy*
-controls what :func:`~literalizer.literalize` does when the input data
-has mixed-type values but the target language's natural collection type
-cannot hold them.
+Some target languages can hold a collection whose elements have different types; others require every element of a list, or every value of a map, to share one static type.
+A *heterogeneous strategy* controls what :func:`~literalizer.literalize` does when the input data has mixed-type values but the target language's natural collection type cannot hold them.
 
-Every built-in language exposes the strategy as a
-``heterogeneous_strategy`` constructor argument whose value comes from
-the language's ``heterogeneous_strategies`` enum.  The default for every
-language is ``ERROR``.
+Every built-in language exposes the strategy as a ``heterogeneous_strategy`` constructor argument whose value comes from the language's ``heterogeneous_strategies`` enum.
+The default for every language is ``ERROR``.
 
 What "heterogeneous" means here
 -------------------------------
 
-A value is heterogeneous when a single collection mixes more than one
-scalar type, or a map mixes value types that a strict-map language
-cannot unify.  Two shapes come up most often:
+A value is heterogeneous when a single collection mixes more than one scalar type, or a map mixes value types that a strict-map language cannot unify.
+Two shapes come up most often:
 
-* A **list** whose elements are not all the same scalar type, e.g.
-  ``[1, "two", 3.0]``.  In a dynamically typed language this is an
-  ordinary list; in Rust it is not a valid ``Vec<T>``.
-* A **record-shaped dict**: a non-empty, string-keyed dict whose values
-  mix scalars with at least one container, e.g.
-  ``{"id": 100, "blocks": [102, 103]}``.  Conceptually this is a record
-  (a struct), not a map, so a strict-map language has no ``HashMap``
-  that fits it.
+* A **list** whose elements are not all the same scalar type, e.g. ``[1, "two", 3.0]``.
+  In a dynamically typed language this is an ordinary list; in Rust it is not a valid ``Vec<T>``.
+* A **record-shaped dict**: a non-empty, string-keyed dict whose values mix scalars with at least one container, e.g. ``{"id": 100, "blocks": [102, 103]}``.
+  Conceptually this is a record (a struct), not a map, so a strict-map language has no ``HashMap`` that fits it.
 
-Languages whose native collections are already heterogeneous (most
-dynamically typed languages, plus formats such as JSON5, YAML, and
-TOML) never reach a strategy: the data is representable as-is, so they
-expose only ``ERROR`` and never raise for these inputs.
+Languages whose native collections are already heterogeneous (most dynamically typed languages, plus formats such as JSON5, YAML, and TOML) never reach a strategy: the data is representable as-is, so they expose only ``ERROR`` and never raise for these inputs.
 
 The strategies
 --------------
@@ -42,14 +28,9 @@ The strategies
 ``ERROR`` (default)
 ~~~~~~~~~~~~~~~~~~~
 
-Refuse to render data the target language's natural collection type
-cannot hold.  :func:`~literalizer.literalize` raises
-:class:`~literalizer.exceptions.HeterogeneousScalarCollectionError`
-(or :class:`~literalizer.exceptions.HeterogeneousSiblingListsError`,
-or :class:`~literalizer.exceptions.MixedDictValuesError`) instead of
-emitting code the target compiler would reject.  This is the safe
-default and matches the strict-typing convention of statically typed
-languages.
+Refuse to render data the target language's natural collection type cannot hold.
+:func:`~literalizer.literalize` raises :class:`~literalizer.exceptions.HeterogeneousScalarCollectionError` (or :class:`~literalizer.exceptions.HeterogeneousSiblingListsError`, or :class:`~literalizer.exceptions.MixedDictValuesError`) instead of emitting code the target compiler would reject.
+This is the safe default and matches the strict-typing convention of statically typed languages.
 
 .. code-block:: python
 
@@ -74,19 +55,11 @@ languages.
 ``TAGGED_ENUM`` (and its per-language equivalents)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Generate a sum type in the preamble that contains only the variants
-actually present in the data, and wrap each heterogeneous scalar in the
-matching variant.  This keeps the collection homogeneous (every element
-is now the one wrapper type) while preserving each value's original
-type at the variant level.
+Generate a sum type in the preamble that contains only the variants actually present in the data, and wrap each heterogeneous scalar in the matching variant.
+This keeps the collection homogeneous (every element is now the one wrapper type) while preserving each value's original type at the variant level.
 
-This family appears under different names because each language's sum
-type is different: ``TAGGED_ENUM`` on :class:`~literalizer.Rust` (a
-tagged ``enum``), ``UNION_TYPE`` on :class:`~literalizer.Dhall`,
-``VARIANT`` on :class:`~literalizer.Mojo`, ``OBJECT_VARIANT`` on
-:class:`~literalizer.Nim`, and ``INTERFACE`` on :class:`~literalizer.V`.
-The generated type's name is configurable (for example
-``Rust.heterogeneous_value_enum_name``, default ``"Value"``).
+This family appears under different names because each language's sum type is different: ``TAGGED_ENUM`` on :class:`~literalizer.Rust` (a tagged ``enum``), ``UNION_TYPE`` on :class:`~literalizer.Dhall`, ``VARIANT`` on :class:`~literalizer.Mojo`, ``OBJECT_VARIANT`` on :class:`~literalizer.Nim`, and ``INTERFACE`` on :class:`~literalizer.V`.
+The generated type's name is configurable (for example ``Rust.heterogeneous_value_enum_name``, default ``"Value"``).
 
 .. code-block:: python
 
@@ -121,24 +94,17 @@ The generated type's name is configurable (for example
        "}",
    )
 
-A tagged enum cannot wrap container values, so it does not help a
-record-shaped dict whose fields mix scalars with a list or another
-dict.  Use ``RECORD`` for that.
+A tagged enum cannot wrap container values, so it does not help a record-shaped dict whose fields mix scalars with a list or another dict.
+Use ``RECORD`` for that.
 
 ``RECORD``
 ~~~~~~~~~~
 
-Treat each record-shaped dict (non-empty, string-keyed) as a generated
-struct/record declared in the preamble plus a matching struct literal,
-so its fields may legitimately mix scalars and containers.  Each
-distinct ordered key set becomes one declaration; the declaration name
-prefix is configurable via ``record_struct_name_prefix`` (default
-``"Record"``).
+Treat each record-shaped dict (non-empty, string-keyed) as a generated struct/record declared in the preamble plus a matching struct literal, so its fields may legitimately mix scalars and containers.
+Each distinct ordered key set becomes one declaration; the declaration name prefix is configurable via ``record_struct_name_prefix`` (default ``"Record"``).
 
-This is the right strategy for data that is conceptually a record, not
-a map.  On :class:`~literalizer.Python` (whose ``dict`` is already
-heterogeneous) it is purely an idiomatic-output choice; the default
-``ERROR`` strategy renders the same data as a plain ``dict``.
+This is the right strategy for data that is conceptually a record, not a map.
+On :class:`~literalizer.Python` (whose ``dict`` is already heterogeneous) it is purely an idiomatic-output choice; the default ``ERROR`` strategy renders the same data as a plain ``dict``.
 
 .. code-block:: python
 
@@ -199,54 +165,33 @@ heterogeneous) it is purely an idiomatic-output choice; the default
 ``TUPLE``
 ~~~~~~~~~
 
-Render a fixed-length heterogeneous **scalar** array (all elements
-scalar, spanning at least two scalar types) as the language's native
-fixed-length tuple instead of rejecting it or widening it to a
-homogeneous list.  Where the language also has ``RECORD``, ``TUPLE``
-composes with it, so a record field whose value is such an array
-becomes a tuple-typed field.  Some languages cap the tuple length
-(:class:`~literalizer.Kotlin` has only ``Pair`` and ``Triple`` and
-raises :class:`~literalizer.exceptions.TupleArityNotRepresentableError`
-otherwise); :class:`~literalizer.Rust` and :class:`~literalizer.Scala`
-impose no length limit.
+Render a fixed-length heterogeneous **scalar** array (all elements scalar, spanning at least two scalar types) as the language's native fixed-length tuple instead of rejecting it or widening it to a homogeneous list.
+Where the language also has ``RECORD``, ``TUPLE`` composes with it, so a record field whose value is such an array becomes a tuple-typed field.
+Some languages cap the tuple length (:class:`~literalizer.Kotlin` has only ``Pair`` and ``Triple`` and raises :class:`~literalizer.exceptions.TupleArityNotRepresentableError` otherwise); :class:`~literalizer.Rust` and :class:`~literalizer.Scala` impose no length limit.
 
 Which should I use? Heterogeneous strategies vs. JSON value types
 -----------------------------------------------------------------
 
 A heterogeneous strategy is not the only way to render mixed-type data.
-Several languages also expose a ``json_type`` constructor argument that
-renders the whole value through a single runtime JSON value type (for
-example ``Rust.json_types.SERDE_JSON_VALUE`` yielding
-``serde_json::Value``).  Both features accept input such as
-``[1, "two", 3.0]`` that the language's narrow collection type cannot
-hold, so the same data often qualifies for either one.  They differ in
-the type of the rendered value:
+Several languages also expose a ``json_type`` constructor argument that renders the whole value through a single runtime JSON value type (for example ``Rust.json_types.SERDE_JSON_VALUE`` yielding ``serde_json::Value``).
+Both features accept input such as ``[1, "two", 3.0]`` that the language's narrow collection type cannot hold, so the same data often qualifies for either one.
+They differ in the type of the rendered value:
 
-* A heterogeneous strategy keeps the result **statically typed**.  The
-  generated enum, struct, or tuple preserves each value's original type,
-  and the rendered collection stays a normal typed collection of that
-  wrapper.  Reach for this when the surrounding code is statically typed
-  and you want the compiler to keep tracking the element types, or when
-  the data is conceptually a record (use ``RECORD``).
-* ``json_type`` renders the value as **one runtime JSON value type**
-  (``serde_json::Value``, ``JsonNode``, ``JSON::Any``, and so on).  The
-  static type is uniform and the element types are recovered at runtime.
-  Reach for this when the value is genuinely arbitrary JSON, when you
-  already pass it to a JSON library, or when synthesizing a typed wrapper
-  per shape would be more structure than the data deserves.
+* A heterogeneous strategy keeps the result **statically typed**.
+  The generated enum, struct, or tuple preserves each value's original type, and the rendered collection stays a normal typed collection of that wrapper.
+  Reach for this when the surrounding code is statically typed and you want the compiler to keep tracking the element types, or when the data is conceptually a record (use ``RECORD``).
+* ``json_type`` renders the value as **one runtime JSON value type** (``serde_json::Value``, ``JsonNode``, ``JSON::Any``, and so on).
+  The static type is uniform and the element types are recovered at runtime.
+  Reach for this when the value is genuinely arbitrary JSON, when you already pass it to a JSON library, or when synthesizing a typed wrapper per shape would be more structure than the data deserves.
 
-The two are mutually exclusive for a given render, and some languages
-reject specific combinations (for instance Java, Kotlin, Zig, and Odin
-reject ``RECORD`` while in their ``json_type`` mode).  See
-:ref:`json-value-types` for every ``json_type`` value, its emitted form,
-and the per-language constraints.
+The two are mutually exclusive for a given render, and some languages reject specific combinations (for instance Java, Kotlin, Zig, and Odin reject ``RECORD`` while in their ``json_type`` mode).
+See :ref:`json-value-types` for every ``json_type`` value, its emitted form, and the per-language constraints.
 
 Per-language support matrix
 ---------------------------
 
-Every built-in language supports ``ERROR`` and defaults to it.  The
-table below lists every language that exposes a richer strategy; any
-language not listed exposes ``ERROR`` only.
+Every built-in language supports ``ERROR`` and defaults to it.
+The table below lists every language that exposes a richer strategy; any language not listed exposes ``ERROR`` only.
 
 .. list-table::
    :header-rows: 1
@@ -284,8 +229,7 @@ language not listed exposes ``ERROR`` only.
 Naming the generated type
 -------------------------
 
-The strategies that synthesize a declaration accept a constructor
-argument that controls its name:
+The strategies that synthesize a declaration accept a constructor argument that controls its name:
 
 .. list-table::
    :header-rows: 1
@@ -294,8 +238,7 @@ argument that controls its name:
    * - Argument
      - Applies to
    * - ``record_struct_name_prefix`` (default ``"Record"``)
-     - ``RECORD`` on Rust, Go, Java, Python, Kotlin, Scala, Cpp,
-       Swift, Nim
+     - ``RECORD`` on Rust, Go, Java, Python, Kotlin, Scala, Cpp, Swift, Nim
    * - ``heterogeneous_value_enum_name`` (default ``"Value"``)
      - ``TAGGED_ENUM`` on Rust
    * - ``heterogeneous_value_union_name`` (default ``"Value"``)
@@ -303,14 +246,10 @@ argument that controls its name:
    * - ``heterogeneous_value_variant_name`` (default ``"Value"``)
      - ``VARIANT`` on Mojo, ``OBJECT_VARIANT`` on Nim
 
-Rust, Go, Java, Kotlin, and Scala additionally accept
-``record_shape_names`` to map a specific key set to a custom
-declaration name; see each language's reference entry.
+Rust, Go, Java, Kotlin, and Scala additionally accept ``record_shape_names`` to map a specific key set to a custom declaration name; see each language's reference entry.
 
 .. seealso::
 
-   :ref:`json-value-types` for the runtime JSON value type alternative
-   to a statically typed strategy.
+   :ref:`json-value-types` for the runtime JSON value type alternative to a statically typed strategy.
 
-   :ref:`languages` for every language class and its other format
-   options.
+   :ref:`languages` for every language class and its other format options.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -96,9 +96,8 @@ TOML is read the same way, and its comments are preserved too:
    #     "port": 8080,
    # }
 
-JSON5 is also accepted. Its relaxed syntax, such as comments, single-quoted
-strings, trailing commas, and hexadecimal numbers, is converted to the target
-language:
+JSON5 is also accepted.
+Its relaxed syntax, such as comments, single-quoted strings, trailing commas, and hexadecimal numbers, is converted to the target language:
 
 .. code-block:: python
 
@@ -127,21 +126,15 @@ language:
 Binding the result to a variable
 --------------------------------
 
-By default :func:`~literalizer.literalize` renders a bare literal.  Pass
-``variable_form`` to bind that literal to a variable instead, so the
-output is a statement you can drop straight into source.  There are three
-forms, and the difference is visible in languages that distinguish
-declaring a variable from assigning to one:
+By default :func:`~literalizer.literalize` renders a bare literal.
+Pass ``variable_form`` to bind that literal to a variable instead, so the output is a statement you can drop straight into source.
+There are three forms, and the difference is visible in languages that distinguish declaring a variable from assigning to one:
 
-* :class:`~literalizer.NewVariable` declares a fresh variable (Go's
-  ``config :=``, JavaScript's ``const config =``, Rust's ``let config =``).
+* :class:`~literalizer.NewVariable` declares a fresh variable (Go's ``config :=``, JavaScript's ``const config =``, Rust's ``let config =``).
   This is the form nearly every example uses.
-* :class:`~literalizer.ExistingVariable` assigns to a variable declared
-  elsewhere (``config =``), emitting no declaration keyword.
-* :class:`~literalizer.BothVariableForms` emits a declaration *and* a
-  subsequent assignment together, for showing both styles from one
-  source.  It requires ``wrap_in_file=True`` and a language whose
-  declaration style permits reassigning the same name.
+* :class:`~literalizer.ExistingVariable` assigns to a variable declared elsewhere (``config =``), emitting no declaration keyword.
+* :class:`~literalizer.BothVariableForms` emits a declaration *and* a subsequent assignment together, for showing both styles from one source.
+  It requires ``wrap_in_file=True`` and a language whose declaration style permits reassigning the same name.
 
 The same source, rendered for Go in each form:
 
@@ -203,14 +196,9 @@ The same source, rendered for Go in each form:
        "}"
    )
 
-Whether the two forms differ at all depends on the language.  Python uses
-``config =`` for both declaring and assigning, so with the default
-settings :class:`~literalizer.NewVariable` and
-:class:`~literalizer.ExistingVariable` render identically.  They diverge
-once a feature attaches to the *declaration* specifically: enabling
-``variable_type_hints`` makes :class:`~literalizer.NewVariable` annotate
-the binding (``config: dict[str, str | int] = ...``) while
-:class:`~literalizer.ExistingVariable` stays a bare ``config = ...``.
+Whether the two forms differ at all depends on the language.
+Python uses ``config =`` for both declaring and assigning, so with the default settings :class:`~literalizer.NewVariable` and :class:`~literalizer.ExistingVariable` render identically.
+They diverge once a feature attaches to the *declaration* specifically: enabling ``variable_type_hints`` makes :class:`~literalizer.NewVariable` annotate the binding (``config: dict[str, str | int] = ...``) while :class:`~literalizer.ExistingVariable` stays a bare ``config = ...``.
 
 Use cases
 ---------

--- a/docs/source/json-api-use-case.rst
+++ b/docs/source/json-api-use-case.rst
@@ -1,16 +1,13 @@
 Multi-language API documentation
 =================================
 
-If you maintain a JSON API, your documentation probably needs to show
-request and response examples in every language your callers use.
-|project| generates those native-language literals from a single JSON
-sample so you don't have to write them by hand.
+If you maintain a JSON API, your documentation probably needs to show request and response examples in every language your callers use.
+|project| generates those native-language literals from a single JSON sample so you don't have to write them by hand.
 
 Example
 -------
 
-Suppose your ``POST /users`` endpoint accepts this request body and
-returns this response:
+Suppose your ``POST /users`` endpoint accepts this request body and returns this response:
 
 .. code-block:: json
 

--- a/docs/source/languages.rst
+++ b/docs/source/languages.rst
@@ -4,14 +4,12 @@ Languages
 =========
 
 Every target language is a class in :mod:`literalizer.languages`.
-You import the class, optionally configure it, and pass an instance to
-:func:`~literalizer.literalize`.
+You import the class, optionally configure it, and pass an instance to :func:`~literalizer.literalize`.
 
 Selecting a language
 --------------------
 
-Each language class lives in :mod:`literalizer.languages` and is listed in
-:data:`~literalizer.languages.ALL_LANGUAGES`.
+Each language class lives in :mod:`literalizer.languages` and is listed in :data:`~literalizer.languages.ALL_LANGUAGES`.
 Create an instance with its defaults, or override individual format options:
 
 .. code-block:: python
@@ -42,8 +40,7 @@ Create an instance with its defaults, or override individual format options:
 Format options
 --------------
 
-Language classes define nested :class:`~enum.Enum` classes that control how
-each data type is rendered.
+Language classes define nested :class:`~enum.Enum` classes that control how each data type is rendered.
 The available enums vary by language, but the most common ones are:
 
 .. list-table::
@@ -79,59 +76,38 @@ The available enums vary by language, but the most common ones are:
    * - ``StatementTerminatorStyles``
      - Statement terminator (``SEMICOLON``, ``NEWLINE``, ``NONE``).
 
-Access a language's enum members through the class itself, e.g.
-``Go.sequence_formats.SLICE`` for Go slices or ``Go.date_formats.GO``
-for the ``time.Date(...)`` constructor.
+Access a language's enum members through the class itself, e.g. ``Go.sequence_formats.SLICE`` for Go slices or ``Go.date_formats.GO`` for the ``time.Date(...)`` constructor.
 
-Each ``__init__`` parameter has a sensible default, so you only need to
-specify the options you want to change.
+Each ``__init__`` parameter has a sensible default, so you only need to specify the options you want to change.
 
 Float emission scope
 --------------------
 
-|project| emits a syntactically valid source literal for any finite
-IEEE 754 ``double`` the target language accepts.  Scientific-notation
-output always uses a dotted mantissa (``1.0e+16`` rather than
-``1e+16``) so the result parses as a float in languages whose
-grammars reject a bare integer mantissa (Ada, Cobol, Elixir, Erlang,
-Gleam, Nix, YAML).  Gleam additionally strips the ``+`` from positive
-exponents because its parser rejects the explicit sign; other
-languages keep the ``+`` because YAML's resolver regex requires it to
-recognize the literal as a float.
+|project| emits a syntactically valid source literal for any finite IEEE 754 ``double`` the target language accepts.
+Scientific-notation output always uses a dotted mantissa (``1.0e+16`` rather than ``1e+16``) so the result parses as a float in languages whose grammars reject a bare integer mantissa (Ada, Cobol, Elixir, Erlang, Gleam, Nix, YAML).
+Gleam additionally strips the ``+`` from positive exponents because its parser rejects the explicit sign; other languages keep the ``+`` because YAML's resolver regex requires it to recognize the literal as a float.
 
-Whether a round-trip through a *target ecosystem's* JSON encoder
-preserves edge values such as ``DBL_MAX`` is governed by that
-ecosystem's encoder (precision, integer-vs-float rendering, ``Inf``
-coercion) and is out of scope for the formatter.  Special floats
-(``inf`` / ``nan``) follow each language's ``supports_special_floats``
-policy; targets that have no expression for them (e.g. Gleam's Erlang
-target) raise
-:class:`~literalizer.exceptions.UnrepresentableSpecialFloatError`.
+Whether a round-trip through a *target ecosystem's* JSON encoder preserves edge values such as ``DBL_MAX`` is governed by that ecosystem's encoder (precision, integer-vs-float rendering, ``Inf`` coercion) and is out of scope for the formatter.
+Special floats (``inf`` / ``nan``) follow each language's ``supports_special_floats`` policy; targets that have no expression for them (e.g. Gleam's Erlang target) raise :class:`~literalizer.exceptions.UnrepresentableSpecialFloatError`.
 
 Heterogeneous values
 --------------------
 
-When the input data mixes value types that the target language's
-natural collection type cannot hold, a ``heterogeneous_strategy``
-constructor argument controls the outcome.  Every language defaults to
-``ERROR``; some expose richer strategies such as ``TAGGED_ENUM`` or
-``RECORD``.  See :ref:`heterogeneous-strategies` for the strategies,
-worked examples, and the per-language support matrix.
+When the input data mixes value types that the target language's natural collection type cannot hold, a ``heterogeneous_strategy`` constructor argument controls the outcome.
+Every language defaults to ``ERROR``; some expose richer strategies such as ``TAGGED_ENUM`` or ``RECORD``.
+See :ref:`heterogeneous-strategies` for the strategies, worked examples, and the per-language support matrix.
 
 .. _json-value-types:
 
 JSON value types
 ----------------
 
-Some languages also have a single runtime JSON value type that is a better
-fit than native narrow collection types.  These languages support this
-through the ``json_type`` constructor argument, accessed as
-``<Language>.json_types.<VALUE>``.
+Some languages also have a single runtime JSON value type that is a better fit than native narrow collection types.
+These languages support this through the ``json_type`` constructor argument, accessed as ``<Language>.json_types.<VALUE>``.
 
 .. seealso::
 
-   :ref:`heterogeneous-strategies` for the statically typed alternative,
-   and its "Which should I use?" note comparing the two approaches.
+   :ref:`heterogeneous-strategies` for the statically typed alternative, and its "Which should I use?" note comparing the two approaches.
 
 Rust is the worked example:
 
@@ -149,13 +125,10 @@ Rust is the worked example:
        variable_form=NewVariable(name="payload"),
    )
 
-This emits ``serde_json::json!(...)`` expressions, relaxes Rust's
-homogeneous ``Vec<T>`` / ``HashMap<K, V>`` checks, and requires dict keys
-to be strings so they remain valid JSON object keys.
+This emits ``serde_json::json!(...)`` expressions, relaxes Rust's homogeneous ``Vec<T>`` / ``HashMap<K, V>`` checks, and requires dict keys to be strings so they remain valid JSON object keys.
 
-Every mode requires dict keys to be strings for the same reason.  The
-remaining languages differ only in the emitted form and a few extra
-constraints:
+Every mode requires dict keys to be strings for the same reason.
+The remaining languages differ only in the emitted form and a few extra constraints:
 
 .. list-table::
    :header-rows: 1
@@ -168,8 +141,7 @@ constraints:
    * - Crystal
      - ``JSON_ANY``
      - ``JSON.parse(%(...))`` yielding ``JSON::Any``
-     - Rejects characters that break the ``%(...)`` literal (``\``, ``"``,
-       ``(``, ``)``, ``#{``); rejects integers overflowing signed 64-bit.
+     - Rejects characters that break the ``%(...)`` literal (``\``, ``"``, ``(``, ``)``, ``#{``); rejects integers overflowing signed 64-bit.
    * - Java
      - ``JACKSON_JSON_NODE``
      - ``new ObjectMapper().readTree("...")`` yielding ``JsonNode``
@@ -180,87 +152,60 @@ constraints:
      - ``RECORD`` and ``TUPLE`` ``heterogeneous_strategy`` options rejected.
    * - Scala
      - ``CIRCE``
-     - ``Json.obj(...)`` / ``Json.arr(...)`` with ``Json.fromXxx(...)``
-       scalars yielding ``io.circe.Json``
+     - ``Json.obj(...)`` / ``Json.arr(...)`` with ``Json.fromXxx(...)`` scalars yielding ``io.circe.Json``
      - None beyond string keys.
    * - C#
      - ``SYSTEM_TEXT_JSON_NODE``
-     - ``new JsonObject { ... }`` / ``new JsonArray { ... }`` backed by
-       ``System.Text.Json.Nodes``
-     - Dates / datetimes / times become ISO 8601 strings; the ``const``
-       modifier is rejected (the constructors are runtime expressions).
+     - ``new JsonObject { ... }`` / ``new JsonArray { ... }`` backed by ``System.Text.Json.Nodes``
+     - Dates / datetimes / times become ISO 8601 strings; the ``const`` modifier is rejected (the constructors are runtime expressions).
    * - F#
      - ``SYSTEM_TEXT_JSON_NODE``
-     - ``JsonObject(dict [ ... ])`` / ``JsonArray([| ... |])`` with
-       ``JsonValue.Create(...)`` scalars
-     - Dates / datetimes / times become ISO 8601 strings unless
-       ``datetime_format`` is ``EPOCH``.
+     - ``JsonObject(dict [ ... ])`` / ``JsonArray([| ... |])`` with ``JsonValue.Create(...)`` scalars
+     - Dates / datetimes / times become ISO 8601 strings unless ``datetime_format`` is ``EPOCH``.
    * - Nim
      - ``JSON_NODE``
      - ``%*(...)`` backed by the standard-library ``json`` module
-     - Dates / datetimes become ISO 8601 strings; ``CONST`` is rejected
-       (``%*`` is a runtime macro).
+     - Dates / datetimes become ISO 8601 strings; ``CONST`` is rejected (``%*`` is a runtime macro).
    * - Haskell
      - ``AESON_VALUE``
      - ``[aesonQQ| ... |]`` quasi-quote yielding ``Data.Aeson.Value``
      - None beyond string keys.
    * - Zig
      - ``STD_JSON_VALUE``
-     - ``std.json.parseFromSlice(std.json.Value, allocator, "...", .{})
-       catch unreachable`` with an injected ``std.heap.ArenaAllocator``
-       preamble
-     - Dates / datetimes / times / bytes fold into strings; ``RECORD`` is
-       rejected.
+     - ``std.json.parseFromSlice(std.json.Value, allocator, "...", .{}) catch unreachable`` with an injected ``std.heap.ArenaAllocator`` preamble
+     - Dates / datetimes / times / bytes fold into strings; ``RECORD`` is rejected.
    * - C++
      - ``NLOHMANN_JSON``
-     - ``nlohmann::json::parse(R"json(...)json")`` plus an
-       ``#include <nlohmann/json.hpp>`` preamble line
+     - ``nlohmann::json::parse(R"json(...)json")`` plus an ``#include <nlohmann/json.hpp>`` preamble line
      - Input must not encode the raw-string terminator ``)json"``.
    * - Gleam
      - ``GLEAM_JSON_JSON``
-     - ``json.int`` / ``json.string`` / ``json.preprocessed_array`` /
-       ``json.object`` builders yielding ``gleam/json.Json``
-     - Adds an ``import gleam/json`` line and drops the ``GVal`` ADT;
-       non-finite floats rejected (the Erlang target cannot express them).
+     - ``json.int`` / ``json.string`` / ``json.preprocessed_array`` / ``json.object`` builders yielding ``gleam/json.Json``
+     - Adds an ``import gleam/json`` line and drops the ``GVal`` ADT; non-finite floats rejected (the Erlang target cannot express them).
    * - Elm
      - ``JSON_ENCODE_VALUE``
-     - ``Json.Encode.int`` / ``string`` / ``list identity`` / ``object``
-       calls yielding ``Json.Encode.Value``
-     - Adds an ``import Json.Encode`` line in place of the per-fixture
-       ``Val`` ADT.
+     - ``Json.Encode.int`` / ``string`` / ``list identity`` / ``object`` calls yielding ``Json.Encode.Value``
+     - Adds an ``import Json.Encode`` line in place of the per-fixture ``Val`` ADT.
    * - PureScript
      - ``ARGONAUT_JSON``
-     - ``fromRight jsonNull (jsonParser "...")`` yielding
-       ``Data.Argonaut.Core.Json``
+     - ``fromRight jsonNull (jsonParser "...")`` yielding ``Data.Argonaut.Core.Json``
      - Special floats (``NaN``, ``+Infinity``, ``-Infinity``) rejected.
    * - Scheme
      - ``GUILE_JSON``
-     - Association lists ``(list (cons "k" v) ...)``, vectors
-       ``(vector v ...)``, and the symbol ``'null``, ready for
-       ``scm->json``
-     - Resolves the default mode's object/array ambiguity; special floats
-       (``NaN``, ``+inf.0``, ``-inf.0``) rejected.
+     - Association lists ``(list (cons "k" v) ...)``, vectors ``(vector v ...)``, and the symbol ``'null``, ready for ``scm->json``
+     - Resolves the default mode's object/array ambiguity; special floats (``NaN``, ``+inf.0``, ``-inf.0``) rejected.
    * - Erlang
      - ``OTP_JSON``
-     - UTF-8 binary literals (``<<"..."/utf8>>``) for the built-in
-       ``json`` module; null as the atom ``null``; sets as JSON arrays
+     - UTF-8 binary literals (``<<"..."/utf8>>``) for the built-in ``json`` module; null as the atom ``null``; sets as JSON arrays
      - Requires the ``OTP_27`` built-in ``json:encode/1``.
    * - Odin
      - ``JSON_VALUE``
-     - JSON text parsed at runtime by a package-scope ``_json_parse``
-       helper (over ``core:encoding/json.parse_string``) yielding
-       ``json.Value``
-     - Dates / datetimes / times / bytes fold into strings; ``RECORD`` is
-       rejected.
+     - JSON text parsed at runtime by a package-scope ``_json_parse`` helper (over ``core:encoding/json.parse_string``) yielding ``json.Value``
+     - Dates / datetimes / times / bytes fold into strings; ``RECORD`` is rejected.
 
 Two cases are unusual enough to keep as prose.
 
-OCaml's ``YOJSON_SAFE_T`` mode emits ``Yojson.Safe.t`` polymorphic-variant
-literals directly, keyed by the standard ``yojson`` tag set (``Bool``,
-``Int``, ``Float``, ``String``, ``Null``, ``List``, ``Assoc``,
-``Intlit``), so the rendered binding has the static type ``Yojson.Safe.t``
-instead of OCaml's generated ``val_t`` algebraic type, and the
-``type val_t = ...`` preamble drops out entirely:
+OCaml's ``YOJSON_SAFE_T`` mode emits ``Yojson.Safe.t`` polymorphic-variant literals directly, keyed by the standard ``yojson`` tag set (``Bool``, ``Int``, ``Float``, ``String``, ``Null``, ``List``, ``Assoc``, ``Intlit``), so the rendered binding has the static type ``Yojson.Safe.t`` instead of OCaml's generated ``val_t`` algebraic type, and the ``type val_t = ...`` preamble drops out entirely:
 
 .. code-block:: ocaml
 
@@ -269,18 +214,10 @@ instead of OCaml's generated ``val_t`` algebraic type, and the
        ("tags", `List [`String "red"; `Int 2])
    ]
 
-Dates, datetimes, times, and bytes fold into JSON-friendly strings;
-integers that exceed OCaml's native ``int`` range route through the
-``Intlit`` arbitrary-precision escape hatch (a string-tagged JSON number)
-instead of raising.
+Dates, datetimes, times, and bytes fold into JSON-friendly strings; integers that exceed OCaml's native ``int`` range route through the ``Intlit`` arbitrary-precision escape hatch (a string-tagged JSON number) instead of raising.
 
-D's polarity is reversed from the others: its default already renders
-every value through ``std.json.JSONValue``, so the ``json_type``
-constructor argument selects the inverse mode.  ``D.json_types.STD_JSON_VALUE``
-is the default and matches the other languages' opt-in JSON value
-rendering; passing ``json_type=None`` instead activates a narrow-typed
-mode that mirrors the typed-collection defaults the other languages
-provide:
+D's polarity is reversed from the others: its default already renders every value through ``std.json.JSONValue``, so the ``json_type`` constructor argument selects the inverse mode.
+``D.json_types.STD_JSON_VALUE`` is the default and matches the other languages' opt-in JSON value rendering; passing ``json_type=None`` instead activates a narrow-typed mode that mirrors the typed-collection defaults the other languages provide:
 
 .. code-block:: python
 
@@ -296,33 +233,18 @@ provide:
        variable_form=NewVariable(name="counts"),
    )
 
-This emits raw D scalars, ``T[]`` array literals, and ``V[K]``
-associative-array literals (``auto counts = ["a": 1, "b": 2];``)
-without the ``JSONValue`` wrapper.  Inputs that have no narrow form,
-a heterogeneous list, a heterogeneous-valued dict, an empty list or
-dict (D's ``auto`` cannot infer an element type for an empty literal),
-a set, an ordered map, or a non-record dict, are rejected with
-:class:`~literalizer.exceptions.UnrepresentableInputError`.  The
-``RECORD`` ``heterogeneous_strategy`` is also rejected because it
-already renders record-shaped dicts as generated ``struct`` literals,
-which conflicts with narrow mode's associative-array form.
+This emits raw D scalars, ``T[]`` array literals, and ``V[K]`` associative-array literals (``auto counts = ["a": 1, "b": 2];``) without the ``JSONValue`` wrapper.
+Inputs that have no narrow form, a heterogeneous list, a heterogeneous-valued dict, an empty list or dict (D's ``auto`` cannot infer an element type for an empty literal), a set, an ordered map, or a non-record dict, are rejected with :class:`~literalizer.exceptions.UnrepresentableInputError`.
+The ``RECORD`` ``heterogeneous_strategy`` is also rejected because it already renders record-shaped dicts as generated ``struct`` literals, which conflicts with narrow mode's associative-array form.
 
 Empty mappings on Ada, Lua, PHP, and R
 --------------------------------------
 
-Ada, Lua, PHP, and R all have a runtime representation that cannot
-distinguish an empty mapping from an empty sequence.  Lua's table,
-PHP's array, and R's ``list()`` each serialize an empty mapping the
-same way their JSON encoders serialize an empty sequence (typically
-``[]``).  The Ada literalizer's unified ``A_Val`` aggregate likewise
-collapses an empty ``AMap'[]`` and an empty ``AList'[]`` to the same
-runtime value, so the mapping/sequence distinction is lost on
-round-trip.  ``literalize`` refuses to emit a literal that cannot
-round-trip and raises
-:class:`~literalizer.exceptions.UnrepresentableEmptyDictError` on
-those four languages whenever an empty mapping appears at any depth
-in the input.  Empty sequences are unambiguous and are still
-accepted.
+Ada, Lua, PHP, and R all have a runtime representation that cannot distinguish an empty mapping from an empty sequence.
+Lua's table, PHP's array, and R's ``list()`` each serialize an empty mapping the same way their JSON encoders serialize an empty sequence (typically ``[]``).
+The Ada literalizer's unified ``A_Val`` aggregate likewise collapses an empty ``AMap'[]`` and an empty ``AList'[]`` to the same runtime value, so the mapping/sequence distinction is lost on round-trip.
+``literalize`` refuses to emit a literal that cannot round-trip and raises :class:`~literalizer.exceptions.UnrepresentableEmptyDictError` on those four languages whenever an empty mapping appears at any depth in the input.
+Empty sequences are unambiguous and are still accepted.
 
 .. code-block:: python
 
@@ -347,10 +269,8 @@ accepted.
 Forth visitor stream
 --------------------
 
-Forth has no native mapping or sequence type, so the Forth language
-does not emit a data literal.  Instead it emits a colon definition that
-executes a sequence of small constructor words, one per structural
-event in the document:
+Forth has no native mapping or sequence type, so the Forth language does not emit a data literal.
+Instead it emits a colon definition that executes a sequence of small constructor words, one per structural event in the document:
 
 ============  ===========================  =================================
 Word          Stack effect                 Meaning
@@ -378,12 +298,8 @@ For example, ``{"name": "Alice", "tags": [1, 2]}`` is literalized to:
     -obj
    ;
 
-The constructor words are the protocol; the caller supplies their
-bindings.  The Forth language ships a default binding in
-``src/literalizer/languages/forth_prelude.fs`` that writes JSON to a
-shared output stream through the Forth Foundation Library ``jos``
-module, so loading the prelude and then running ``my_data`` prints the
-document as JSON out of the box:
+The constructor words are the protocol; the caller supplies their bindings.
+The Forth language ships a default binding in ``src/literalizer/languages/forth_prelude.fs`` that writes JSON to a shared output stream through the Forth Foundation Library ``jos`` module, so loading the prelude and then running ``my_data`` prints the document as JSON out of the box:
 
 .. code-block:: forth
 
@@ -391,32 +307,20 @@ document as JSON out of the box:
    \ ... the literalized : my_data ... ; definition ...
    my_data json-out str-get type
 
-To consume the same definition another way -- to build a Forth-side
-data structure, walk into custom storage, compute over the values, or
-emit a different format -- redefine any of the constructor words before
-running the definition.  Nothing in the definition is tied to JSON
-beyond the bindings the caller chooses to load.
+To consume the same definition another way -- to build a Forth-side data structure, walk into custom storage, compute over the values, or emit a different format -- redefine any of the constructor words before running the definition.
+Nothing in the definition is tied to JSON beyond the bindings the caller chooses to load.
 
 Custom language implementations
 -------------------------------
 
-To support a language that is not built in, create a class that satisfies
-the :class:`~literalizer.Language` protocol, using ``metaclass=LanguageCls``
-and defining the required nested enum classes and attributes.
+To support a language that is not built in, create a class that satisfies the :class:`~literalizer.Language` protocol, using ``metaclass=LanguageCls`` and defining the required nested enum classes and attributes.
 
-When an attribute is part of the :class:`~literalizer.Language` protocol but
-should resolve to ``None``, expose that value through a descriptor or property
-instead of storing literal ``None`` on the class.  CPython treats class-level
-``None`` as "attribute is not implemented" during runtime protocol checks,
-which can prevent ABC cache warming for large ``@runtime_checkable`` protocols;
-see `python/cpython#102433 <https://github.com/python/cpython/issues/102433>`__.
-Built-in languages use shared descriptors such as ``no_pygments_name`` and
-``no_format_integer_widened`` for this pattern.
+When an attribute is part of the :class:`~literalizer.Language` protocol but should resolve to ``None``, expose that value through a descriptor or property instead of storing literal ``None`` on the class.
+CPython treats class-level ``None`` as "attribute is not implemented" during runtime protocol checks, which can prevent ABC cache warming for large ``@runtime_checkable`` protocols; see `python/cpython#102433 <https://github.com/python/cpython/issues/102433>`__.
+Built-in languages use shared descriptors such as ``no_pygments_name`` and ``no_format_integer_widened`` for this pattern.
 
-Look at any built-in language module under ``literalizer/languages/`` for a
-complete working example.
-The :class:`~literalizer.Language` protocol documents every required
-attribute.
+Look at any built-in language module under ``literalizer/languages/`` for a complete working example.
+The :class:`~literalizer.Language` protocol documents every required attribute.
 
 Built-in languages
 ------------------

--- a/docs/source/unreleased.rst
+++ b/docs/source/unreleased.rst
@@ -1,8 +1,7 @@
 Unreleased changes
 ==================
 
-Changes that have landed on the main branch but are not yet part of a
-tagged release.  These entries are assembled into the
-:doc:`changelog` when the next release is published.
+Changes that have landed on the main branch but are not yet part of a tagged release.
+These entries are assembled into the :doc:`changelog` when the next release is published.
 
 .. towncrier-draft-entries::


### PR DESCRIPTION
Reformats the docs/source prose to one sentence per line (semantic line breaks), applying it to paragraphs, list items, list-table cells, and admonition text across eight `.rst` files. Code blocks, directives, the Forth simple table, section titles, and inline literals are left untouched. This matches the convention already used in `contributing.rst` and the project's existing `doc8` `max_line_length = 2000` setting. Verified with `sphinx-build -W`, `doc8`, `sphinx-lint`, and the full pre-commit suite (including the doccmd hooks that re-validate the code examples), all passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation formatting only; no runtime, API, or build-logic changes beyond existing doc validation.
> 
> **Overview**
> Reformats narrative prose in **eight** `docs/source/*.rst` guides to **one sentence per line** (semantic line breaks), matching `contributing.rst` and the existing `doc8` `max_line_length = 2000` setup.
> 
> Coverage includes normal paragraphs, bullet items, `list-table` cells, and `seealso` text in files such as `api-reference.rst`, `common-errors.rst`, `function-call-use-case.rst`, `heterogeneous-strategies.rst`, `index.rst`, `languages.rst`, and `unreleased.rst`.
> 
> **Unchanged:** code blocks, directives, section titles, inline literals, and the Forth simple table—wording and technical content are the same; only line wrapping in prose changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 320168eb97ce71b27e77bc6b3b7a8f576750ce4c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->