### PR TITLE
Docs: source parsing-error meanings and resolutions from docstrings

### DIFF
--- a/docs/source/common-errors.rst
+++ b/docs/source/common-errors.rst
@@ -14,29 +14,20 @@ Parsing the input
 
 Raised while reading ``source`` in the declared ``input_format``, before any language-specific rendering.
 
-.. list-table::
-   :header-rows: 1
-   :widths: 30 35 35
+.. autoexception:: literalizer.exceptions.ParseError
+   :no-index:
 
-   * - Exception
-     - Cause
-     - How to resolve
-   * - :class:`~literalizer.exceptions.ParseError`
-     - Base class for every input-parsing failure.
-       Catch this to handle any malformed input uniformly.
-     - Validate the source against its declared ``input_format``.
-   * - :class:`~literalizer.exceptions.JSONParseError`
-     - The ``source`` is not well-formed JSON.
-     - Fix the JSON syntax, or pass the correct ``input_format`` if the data is really JSON5, YAML, or TOML.
-   * - :class:`~literalizer.exceptions.JSON5ParseError`
-     - The ``source`` is not well-formed JSON5.
-     - Fix the JSON5 syntax, or choose the matching ``input_format``.
-   * - :class:`~literalizer.exceptions.YAMLParseError`
-     - The ``source`` is not well-formed YAML.
-     - Fix the YAML syntax, or choose the matching ``input_format``.
-   * - :class:`~literalizer.exceptions.TOMLParseError`
-     - The ``source`` is not well-formed TOML.
-     - Fix the TOML syntax, or choose the matching ``input_format``.
+.. autoexception:: literalizer.exceptions.JSONParseError
+   :no-index:
+
+.. autoexception:: literalizer.exceptions.JSON5ParseError
+   :no-index:
+
+.. autoexception:: literalizer.exceptions.YAMLParseError
+   :no-index:
+
+.. autoexception:: literalizer.exceptions.TOMLParseError
+   :no-index:
 
 Mixed-type collections
 ----------------------

--- a/src/literalizer/exceptions.py
+++ b/src/literalizer/exceptions.py
@@ -2,23 +2,44 @@
 
 
 class ParseError(Exception):
-    """Raised when input cannot be parsed into a data structure."""
+    """Raised when input cannot be parsed into a data structure.
+
+    Base class for every input-parsing failure; catch it to handle any
+    malformed input uniformly.  To resolve, validate the source against
+    its declared ``input_format``.
+    """
 
 
 class JSONParseError(ParseError):
-    """Raised when a JSON string cannot be parsed."""
+    """Raised when a JSON string cannot be parsed.
+
+    To resolve, fix the JSON syntax, or pass the correct ``input_format``
+    if the data is really JSON5, YAML, or TOML.
+    """
 
 
 class YAMLParseError(ParseError):
-    """Raised when a YAML string cannot be parsed."""
+    """Raised when a YAML string cannot be parsed.
+
+    To resolve, fix the YAML syntax, or choose the matching
+    ``input_format``.
+    """
 
 
 class TOMLParseError(ParseError):
-    """Raised when a TOML string cannot be parsed."""
+    """Raised when a TOML string cannot be parsed.
+
+    To resolve, fix the TOML syntax, or choose the matching
+    ``input_format``.
+    """
 
 
 class JSON5ParseError(ParseError):
-    """Raised when a JSON5 string cannot be parsed."""
+    """Raised when a JSON5 string cannot be parsed.
+
+    To resolve, fix the JSON5 syntax, or choose the matching
+    ``input_format``.
+    """
 
 
 class InvalidDictKeyError(Exception):


### PR DESCRIPTION
First slice of #2817: folds the resolution guidance for the input-parsing exceptions into their docstrings in `exceptions.py` and renders the "Parsing the input" section of `common-errors.rst` with `autoexception` directives instead of a hand-maintained Cause/How-to-resolve table, so each exception's meaning lives in one place. The directives use `:no-index:` so the `api-reference.rst` `automodule` stays the canonical cross-reference target and the `-W` docs build does not fail on duplicate object descriptions. The remaining five stage tables are left for follow-up under #2817.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and docstring-only changes with no runtime or API behavior impact.
> 
> **Overview**
> **Parsing the input** guidance now lives in the exception docstrings in `exceptions.py` instead of a duplicated Cause / How-to-resolve table in `common-errors.rst`.
> 
> The docs page renders those five parsing exceptions via Sphinx `.. autoexception::` directives (with `:no-index:` so `api-reference.rst`’s `automodule` stays the canonical cross-reference target and strict `-W` builds do not hit duplicate descriptions). Other error-stage tables on that page are unchanged for a later slice of the same work (#2817).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6a3dc78c3f229559d89b59af36366c8bcf131b86. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->