### PR TITLE
Docs: generate heterogeneous-strategy support matrix from the registry

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -6,6 +6,8 @@ from pathlib import Path
 from packaging.specifiers import SpecifierSet
 from sphinx_pyproject import SphinxConfig
 
+from literalizer.languages import ALL_LANGUAGES
+
 _pyproject_file = Path(__file__).parent.parent.parent / "pyproject.toml"
 _pyproject_config = SphinxConfig(
     pyproject_file=_pyproject_file,
@@ -17,6 +19,7 @@ author = _pyproject_config.author
 
 extensions = [
     "sphinx_copybutton",
+    "sphinx_jinja",
     "sphinx.ext.autodoc",
     "sphinx.ext.napoleon",
     "sphinx_substitution_extensions",
@@ -36,6 +39,33 @@ towncrier_draft_include_empty = True
 towncrier_draft_working_directory = f"{_pyproject_file.parent}"
 
 templates_path = ["_templates"]
+
+# Build the heterogeneous-strategy support matrix from the language
+# registry so the table in ``heterogeneous-strategies.rst`` (rendered via
+# the ``sphinx_jinja`` extension) cannot drift from the
+# ``heterogeneous_strategies`` enum on each language class.  Every
+# language supports ``ERROR``; only the richer strategies are listed, and
+# a language exposing nothing else is omitted.
+_strategies_by_language = {
+    language.__name__: [
+        member.name
+        for member in language.HeterogeneousStrategies
+        if member.name != "ERROR"
+    ]
+    for language in ALL_LANGUAGES
+}
+jinja_contexts = {
+    "heterogeneous_strategies": {
+        "languages": [
+            {
+                "name": name,
+                "strategies": ", ".join(f"``{member}``" for member in members),
+            }
+            for name, members in sorted(_strategies_by_language.items())
+            if members
+        ],
+    },
+}
 
 # Ambiguous cross-references from identically-named nested classes
 # (DateFormat, DatetimeFormat, BytesFormat) across language modules.

--- a/docs/source/heterogeneous-strategies.rst
+++ b/docs/source/heterogeneous-strategies.rst
@@ -192,39 +192,20 @@ Per-language support matrix
 
 Every built-in language supports ``ERROR`` and defaults to it.
 The table below lists every language that exposes a richer strategy; any language not listed exposes ``ERROR`` only.
+It is generated from the language registry at build time, so it always matches the ``heterogeneous_strategies`` enum on each language class.
 
-.. list-table::
-   :header-rows: 1
-   :widths: 25 75
+.. jinja:: heterogeneous_strategies
 
-   * - Language
-     - Strategies (besides ``ERROR``)
-   * - :class:`~literalizer.Rust`
-     - ``TAGGED_ENUM``, ``RECORD``, ``TUPLE``
-   * - :class:`~literalizer.Kotlin`
-     - ``RECORD``, ``TUPLE``
-   * - :class:`~literalizer.Scala`
-     - ``RECORD``, ``TUPLE``
-   * - :class:`~literalizer.Go`
-     - ``RECORD``
-   * - :class:`~literalizer.Java`
-     - ``RECORD``
-   * - :class:`~literalizer.Python`
-     - ``RECORD``
-   * - :class:`~literalizer.Swift`
-     - ``RECORD``
-   * - :class:`~literalizer.Cpp`
-     - ``RECORD``, ``TUPLE``
-   * - :class:`~literalizer.TypeScript`
-     - ``TUPLE``
-   * - :class:`~literalizer.Dhall`
-     - ``UNION_TYPE``
-   * - :class:`~literalizer.Mojo`
-     - ``VARIANT``
-   * - :class:`~literalizer.Nim`
-     - ``OBJECT_VARIANT``, ``RECORD``
-   * - :class:`~literalizer.V`
-     - ``INTERFACE``
+   .. list-table::
+      :header-rows: 1
+      :widths: 25 75
+
+      * - Language
+        - Strategies (besides ``ERROR``)
+      {% for language in languages %}
+      * - :class:`~literalizer.{{ language.name }}`
+        - {{ language.strategies }}
+      {%- endfor %}
 
 Naming the generated type
 -------------------------

--- a/newsfragments/2818.change
+++ b/newsfragments/2818.change
@@ -1,0 +1,1 @@
+Generate the per-language heterogeneous-strategy support matrix in the documentation from the language registry at build time (rendered with the ``sphinx-jinja`` extension), so it can no longer drift from the ``heterogeneous_strategies`` enum on each language class.  This also corrects the previously stale matrix, which omitted several languages that now expose ``RECORD``.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,6 +80,12 @@ optional-dependencies.dev = [
     "shfmt-py==4.0.0",
     "sphinx==9.1.0",
     "sphinx-copybutton==0.5.2",
+    # ``sphinx-jinja`` renders the heterogeneous-strategy support matrix in
+    # ``docs/source/heterogeneous-strategies.rst`` from the language
+    # registry (via the ``jinja_contexts`` built in ``conf.py``) so the
+    # table cannot drift from the per-language ``heterogeneous_strategies``
+    # enums.
+    "sphinx-jinja==2.0.2",
     "sphinx-lint==1.0.2",
     "sphinx-pyproject==0.3.0",
     "sphinx-substitution-extensions==2026.1.12",
@@ -539,6 +545,9 @@ ignore_names = [
     "INTERFACE",
     "intersphinx_mapping",
     "JDK_16",
+    # Read by the ``sphinx_jinja`` extension to populate ``.. jinja::``
+    # blocks; see the support-matrix context built in ``conf.py``.
+    "jinja_contexts",
     "JSON_PP_REF",
     "JSON_PP_SINGLETON",
     "language",


### PR DESCRIPTION
The per-language support matrix in `heterogeneous-strategies.rst` was a hand-maintained table that had silently gone stale, omitting C, Crystal, C#, D, Odin, V, and Zig from `RECORD` (and listing V with only `INTERFACE`). It now renders from the language registry at build time via the `sphinx-jinja` extension: `conf.py` builds the rows from each language's `HeterogeneousStrategies` enum into a `jinja_contexts` entry, and a `.. jinja::` block in the `.rst` emits the `list-table`, so the table can no longer drift. Adds the `sphinx-jinja==2.0.2` dev dependency and a `jinja_contexts` vulture allowlist entry. Closes #2818.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and dev-dependency only; no runtime or library API changes.
> 
> **Overview**
> The per-language heterogeneous-strategy table in `heterogeneous-strategies.rst` is no longer hand-maintained. **Sphinx** now builds it at doc-build time from `ALL_LANGUAGES` and each language’s `HeterogeneousStrategies` enum (excluding `ERROR`), via **`sphinx-jinja`** and a `.. jinja::` block fed by `jinja_contexts` in `conf.py`.
> 
> The prose notes the matrix is generated so it stays aligned with the enums. A **towncrier** fragment records the fix for the stale table (missing languages with `RECORD`, etc.). **`pyproject.toml`** adds `sphinx-jinja==2.0.2` and a **vulture** allowlist entry for `jinja_contexts`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 931f2838305e5d90163356efa7f41bfe01792c5f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->