### PR TITLE
Link to sphinx-literalizer in README and docs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -92,6 +92,11 @@ CLI
 
 A command-line interface is available at `literalizer-cli <https://github.com/adamtheturtle/literalizer-cli>`__.
 
+Sphinx extension
+----------------
+
+A Sphinx extension is available at `sphinx-literalizer <https://github.com/adamtheturtle/sphinx-literalizer>`__.
+
 Full documentation
 ------------------
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -213,6 +213,11 @@ CLI
 
 A command-line interface is available at `literalizer-cli <https://github.com/adamtheturtle/literalizer-cli>`__.
 
+Sphinx extension
+----------------
+
+A Sphinx extension is available at `sphinx-literalizer <https://github.com/adamtheturtle/sphinx-literalizer>`__.
+
 Reference
 ---------
 


### PR DESCRIPTION
Add a "Sphinx extension" section linking to `sphinx-literalizer` in both `README.rst` and `docs/source/index.rst`, alongside the existing `literalizer-cli` link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or API impact.
> 
> **Overview**
> Adds a **Sphinx extension** section to `README.rst` and `docs/source/index.rst`, mirroring the existing **CLI** blurb and linking to [`sphinx-literalizer`](https://github.com/adamtheturtle/sphinx-literalizer).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f0f6645e21973311b7b87ee538e9a9a1f3374326. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->