### PR TITLE
Docs: document the C and Cobol CJSON json_type modes

### DIFF
--- a/docs/source/languages.rst
+++ b/docs/source/languages.rst
@@ -202,6 +202,14 @@ The remaining languages differ only in the emitted form and a few extra constrai
      - ``JSON_VALUE``
      - JSON text parsed at runtime by a package-scope ``_json_parse`` helper (over ``core:encoding/json.parse_string``) yielding ``json.Value``
      - Dates / datetimes / times / bytes fold into strings; ``RECORD`` is rejected.
+   * - C
+     - ``CJSON``
+     - A ``cJSON_Create*(...)`` node tree composed with ``cJSON_AddItemToObject`` / ``cJSON_AddItemToArray`` plus an ``#include <cjson/cJSON.h>`` preamble, yielding ``cJSON *``
+     - Integers render through ``cJSON_CreateNumber((double)...)`` (``cJSON`` has no integer node); ``RECORD`` is rejected.
+   * - Cobol
+     - ``CJSON``
+     - The same ``cJSON_Create*`` tree built through GnuCOBOL's C ``CALL`` interface across the ``WORKING-STORAGE`` and ``PROCEDURE`` divisions, yielding ``cJSON *``
+     - Integers are stored in a ``COMP-2`` (C ``double``) item; values beyond COBOL's widest integer are rejected.
 
 Two cases are unusual enough to keep as prose.
 


### PR DESCRIPTION
Add the previously missing C and Cobol `CJSON` rows to the `json_type` support table in `languages.rst`, documenting each mode's emitted form (a `cJSON_Create*` node tree) and its constraints. The heterogeneous-strategy table generation that was previously on this branch has been reverted, so this PR is now scoped to just that documentation fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates to the language reference; no runtime or API behavior changes.
> 
> **Overview**
> Documents **C** and **Cobol** support for the shared **`CJSON`** `json_type` in the **JSON value types** reference table in `languages.rst`.
> 
> Each new row describes the emitted **`cJSON`** tree (create/add APIs, `#include` or GnuCOBOL `CALL` wiring), the resulting **`cJSON *`** type, and constraints such as **double-only numbers**, **`RECORD`** rejection, and Cobol **integer range** limits.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d0502d84078a7ec9561c402119b98f2fe0431218. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->