### PR TITLE
Split lint CI by prek group instead of hook stage

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -25,18 +25,15 @@ jobs:
       matrix:
         python-version: ['3.12', '3.13', '3.14']
         platform: [ubuntu-latest, windows-latest]
-        hook-stage: [pre-commit, pre-push, manual]
-        # Windows is dropped from the heavy stages (pre-push, manual)
-        # because the type checkers and pylint dominate wall time on
-        # Windows runners and are platform-agnostic in practice. Re-add
-        # Windows here once prek supports hook groups so we can shard
-        # the heavy hooks across runners:
-        # https://github.com/j178/prek/issues/1385
-        exclude:
-          - platform: windows-latest
-            hook-stage: pre-push
-          - platform: windows-latest
-            hook-stage: manual
+        # We shard the hooks into prek groups (defined via ``groups:`` in
+        # ``.pre-commit-config.yaml``) rather than running them by stage,
+        # so the heavy hooks are spread across runners and each group is
+        # light enough to run on Windows too:
+        #   - ``fast``: the quick pre-commit-stage hooks
+        #   - ``typecheck``: mypy / pyright / ty / pyrefly (+ check-manifest)
+        #   - ``docs``: pylint, the Sphinx builds, spelling, linkcheck
+        # ``prek run --group`` needs prek >= 0.4.4.
+        group: [fast, typecheck, docs]
 
     runs-on: ${{ matrix.platform }}
 
@@ -52,8 +49,7 @@ jobs:
 
       - name: Lint
         shell: bash
-        run: uv run --extra=dev prek run --all-files --hook-stage ${{ matrix.hook-stage }}
-          --verbose
+        run: uv run --extra=dev prek run --all-files --group ${{ matrix.group }} --verbose
         env:
           UV_PYTHON: ${{ matrix.python-version }}
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -26,14 +26,17 @@ jobs:
         python-version: ['3.12', '3.13', '3.14']
         platform: [ubuntu-latest, windows-latest]
         # We shard the hooks into prek groups (defined via ``groups:`` in
-        # ``.pre-commit-config.yaml``) rather than running them by stage,
-        # so the heavy hooks are spread across runners and each group is
-        # light enough to run on Windows too:
-        #   - ``fast``: the quick pre-commit-stage hooks
-        #   - ``typecheck``: mypy / pyright / ty / pyrefly (+ check-manifest)
-        #   - ``docs``: pylint, the Sphinx builds, spelling, linkcheck
+        # ``.pre-commit-config.yaml``) rather than running them by stage.
+        # The slow hooks each get their own group so they run on separate
+        # runners in parallel instead of serialized on one, which keeps
+        # every group light enough to also run on Windows:
+        #   - ``fast``: the quick pre-commit-stage hooks (+ check-manifest)
+        #   - ``mypy`` / ``pyright`` / ``ty`` / ``pyrefly``: one type
+        #     checker (and its docs variant) per runner
+        #   - ``pylint``: pylint + pylint-docs
+        #   - ``docs``: the Sphinx html build, spelling, linkcheck
         # ``prek run --group`` needs prek >= 0.4.4.
-        group: [fast, typecheck, docs]
+        group: [fast, mypy, pyright, ty, pyrefly, pylint, docs]
 
     runs-on: ${{ matrix.platform }}
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,21 +24,27 @@ jobs:
     strategy:
       matrix:
         python-version: ['3.12', '3.13', '3.14']
-        platform: [ubuntu-latest, windows-latest]
-        # We shard the hooks into prek groups (defined via ``groups:`` in
-        # ``.pre-commit-config.yaml``) rather than running them by stage.
-        # The slow hooks each get their own group so they run on separate
-        # runners in parallel instead of serialized on one, which keeps
-        # every group light enough to also run on Windows:
+        # We select hooks by prek group (defined via ``groups:`` in
+        # ``.pre-commit-config.yaml``) rather than by stage, so the slow
+        # hooks run on separate runners in parallel instead of serialized
+        # within one stage:
         #   - ``fast``: the quick pre-commit-stage hooks (+ check-manifest)
-        #   - ``mypy`` / ``pyright`` / ``ty`` / ``pyrefly``: one type
-        #     checker (and its docs variant) per runner
+        #   - ``typecheck``: mypy / pyright / ty / pyrefly (+ docs variants)
         #   - ``pylint``: pylint + pylint-docs
         #   - ``docs``: the Sphinx html build, spelling, linkcheck
         # ``prek run --group`` needs prek >= 0.4.4.
-        group: [fast, mypy, pyright, ty, pyrefly, pylint, docs]
+        #
+        # Lint is Linux-only: every hook here (formatters, type checkers,
+        # spelling, ...) is platform-agnostic, and the package's runtime
+        # behaviour on Windows is already covered by the test matrix in
+        # ``ci.yml`` (which runs pytest on ``windows-latest``). Splitting
+        # these hooks across more runners than this buys nothing: the
+        # heaviest group (``docs``) sets the wall-clock floor, the rest
+        # finish well under it, and extra matrix cells only add runner
+        # queueing.
+        group: [fast, typecheck, pylint, docs]
 
-    runs-on: ${{ matrix.platform }}
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v6

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -48,67 +48,85 @@ repos:
       - id: check-useless-excludes
         priority: 10
         stages: [pre-commit]
+        groups: [fast]
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0
     hooks:
       - id: check-added-large-files
         priority: 30
         stages: [pre-commit]
+        groups: [fast]
       - id: check-case-conflict
         priority: 40
         stages: [pre-commit]
+        groups: [fast]
       - id: check-executables-have-shebangs
         priority: 60
         stages: [pre-commit]
+        groups: [fast]
       - id: check-merge-conflict
         priority: 20
         stages: [pre-commit]
+        groups: [fast]
       - id: check-shebang-scripts-are-executable
         priority: 70
         stages: [pre-commit]
+        groups: [fast]
       - id: check-symlinks
         priority: 50
         stages: [pre-commit]
+        groups: [fast]
       - id: check-json
         priority: 90
         stages: [pre-commit]
+        groups: [fast]
       - id: check-toml
         # Integration test fixtures use TOML v1.1 (multiline inline tables),
         # which tomllib (used by check-toml) does not support.
         exclude: ^tests/integration/cases/
         priority: 91
         stages: [pre-commit]
+        groups: [fast]
       - id: check-vcs-permalinks
         priority: 80
         stages: [pre-commit]
+        groups: [fast]
       - id: check-yaml
         priority: 92
         stages: [pre-commit]
+        groups: [fast]
       - id: end-of-file-fixer
         priority: 100
         stages: [pre-commit]
+        groups: [fast]
       - id: file-contents-sorter
         files: spelling_private_dict\.txt$
         priority: 110
         stages: [pre-commit]
+        groups: [fast]
       - id: trailing-whitespace
         priority: 120
         stages: [pre-commit]
+        groups: [fast]
   - repo: https://github.com/pre-commit/pygrep-hooks
     rev: v1.10.0
     hooks:
       - id: rst-directive-colons
         priority: 410
         stages: [pre-commit]
+        groups: [fast]
       - id: rst-inline-touching-normal
         priority: 420
         stages: [pre-commit]
+        groups: [fast]
       - id: text-unicode-replacement-char
         priority: 430
         stages: [pre-commit]
+        groups: [fast]
       - id: rst-backticks
         priority: 440
         stages: [pre-commit]
+        groups: [fast]
   - repo: local
     hooks:
       - id: actionlint
@@ -120,6 +138,7 @@ repos:
         additional_dependencies: [&uv_version uv==0.11.7]
         priority: 500
         stages: [pre-commit]
+        groups: [fast]
 
       - id: shellcheck
         name: shellcheck
@@ -130,6 +149,7 @@ repos:
         additional_dependencies: [*uv_version]
         priority: 500
         stages: [pre-commit]
+        groups: [fast]
 
       - id: shellcheck-docs
         name: shellcheck-docs
@@ -140,6 +160,7 @@ repos:
         additional_dependencies: [*uv_version]
         priority: 500
         stages: [pre-commit]
+        groups: [fast]
 
       - id: shfmt
         name: shfmt
@@ -150,6 +171,7 @@ repos:
         additional_dependencies: [*uv_version]
         priority: 130
         stages: [pre-commit]
+        groups: [fast]
 
       - id: shfmt-docs
         name: shfmt-docs
@@ -160,6 +182,7 @@ repos:
         additional_dependencies: [*uv_version]
         priority: 140
         stages: [pre-commit]
+        groups: [fast]
 
       - id: pydocstringformatter
         name: pydocstringformatter
@@ -170,10 +193,12 @@ repos:
         additional_dependencies: [*uv_version]
         priority: 150
         stages: [pre-commit]
+        groups: [fast]
 
       - id: mypy
         name: mypy
         stages: [pre-push]
+        groups: [typecheck]
         priority: 520
         entry: uv run --extra=dev -m mypy --num-workers=4
         language: python
@@ -185,6 +210,7 @@ repos:
       - id: mypy-docs
         name: mypy-docs
         stages: [pre-push]
+        groups: [typecheck]
         priority: 540
         entry: uv run --extra=dev doccmd --no-write-to-file --language=python --command="mypy
           --num-workers=4"
@@ -195,6 +221,7 @@ repos:
       - id: check-manifest
         name: check-manifest
         stages: [pre-push]
+        groups: [typecheck]
         priority: 520
         entry: uv run --extra=dev -m check_manifest
         language: python
@@ -204,6 +231,7 @@ repos:
       - id: pyright
         name: pyright
         stages: [pre-push]
+        groups: [typecheck]
         priority: 520
         entry: uv run --extra=dev -m pyright .
         language: python
@@ -214,6 +242,7 @@ repos:
       - id: pyright-docs
         name: pyright-docs
         stages: [pre-push]
+        groups: [typecheck]
         priority: 540
         entry: uv run --extra=dev doccmd --no-write-to-file --example-workers 0 --language=python
           --command="pyright"
@@ -224,6 +253,7 @@ repos:
       - id: pyright-verifytypes
         name: pyright-verifytypes
         stages: [pre-push]
+        groups: [typecheck]
         priority: 530
         entry: uv run --extra=dev -m pyright --ignoreexternal --verifytypes literalizer
         language: python
@@ -234,6 +264,7 @@ repos:
       - id: ty
         name: ty
         stages: [pre-push]
+        groups: [typecheck]
         priority: 520
         entry: uv run --extra=dev ty check
         language: python
@@ -244,6 +275,7 @@ repos:
       - id: ty-docs
         name: ty-docs
         stages: [pre-push]
+        groups: [typecheck]
         priority: 540
         entry: uv run --extra=dev doccmd --no-write-to-file --example-workers 0 --language=python
           --command="ty check"
@@ -254,6 +286,7 @@ repos:
       - id: pyrefly
         name: pyrefly
         stages: [pre-push]
+        groups: [typecheck]
         priority: 520
         entry: uv run --extra=dev pyrefly check
         language: python
@@ -264,6 +297,7 @@ repos:
       - id: pyrefly-docs
         name: pyrefly-docs
         stages: [pre-push]
+        groups: [typecheck]
         priority: 540
         entry: uv run --extra=dev doccmd --no-write-to-file --example-workers 0 --language=python
           --command="pyrefly check"
@@ -280,6 +314,7 @@ repos:
         additional_dependencies: [*uv_version]
         priority: 510
         stages: [pre-commit]
+        groups: [fast]
 
       - id: vulture-docs
         name: vulture docs
@@ -290,6 +325,7 @@ repos:
         additional_dependencies: [*uv_version]
         priority: 510
         stages: [pre-commit]
+        groups: [fast]
 
       - id: pyroma
         name: pyroma
@@ -300,6 +336,7 @@ repos:
         additional_dependencies: [*uv_version]
         priority: 510
         stages: [pre-commit]
+        groups: [fast]
 
       - id: deptry
         name: deptry
@@ -309,12 +346,14 @@ repos:
         additional_dependencies: [*uv_version]
         priority: 510
         stages: [pre-commit]
+        groups: [fast]
 
       - id: pylint
         name: pylint
         entry: uv run --extra=dev -m pylint *.py src/ tests/ docs/
         language: python
         stages: [manual]
+        groups: [docs]
         priority: 600
         pass_filenames: false
         additional_dependencies: [*uv_version]
@@ -325,6 +364,7 @@ repos:
           --command="pylint"
         language: python
         stages: [manual]
+        groups: [docs]
         priority: 605
         types_or: [markdown, rst]
         additional_dependencies: [*uv_version]
@@ -338,6 +378,7 @@ repos:
         additional_dependencies: [*uv_version]
         priority: 160
         stages: [pre-commit]
+        groups: [fast]
 
       - id: ruff-check-fix-docs
         name: Ruff check fix docs
@@ -347,6 +388,7 @@ repos:
         additional_dependencies: [*uv_version]
         priority: 170
         stages: [pre-commit]
+        groups: [fast]
 
       - id: ruff-format-fix
         name: Ruff format
@@ -357,6 +399,7 @@ repos:
         additional_dependencies: [*uv_version]
         priority: 180
         stages: [pre-commit]
+        groups: [fast]
 
       - id: ruff-format-fix-docs
         name: Ruff format docs
@@ -367,6 +410,7 @@ repos:
         additional_dependencies: [*uv_version]
         priority: 190
         stages: [pre-commit]
+        groups: [fast]
 
       - id: strict-kwargs-fix
         name: strict-kwargs
@@ -375,6 +419,7 @@ repos:
         types_or: [python]
         additional_dependencies: [*uv_version]
         stages: [pre-commit]
+        groups: [fast]
         require_serial: true
 
       - id: doc8
@@ -385,6 +430,7 @@ repos:
         additional_dependencies: [*uv_version]
         priority: 500
         stages: [pre-commit]
+        groups: [fast]
 
       - id: interrogate
         name: interrogate
@@ -395,6 +441,7 @@ repos:
         additional_dependencies: [*uv_version]
         priority: 510
         stages: [pre-commit]
+        groups: [fast]
 
       - id: interrogate-docs
         name: interrogate docs
@@ -405,6 +452,7 @@ repos:
         additional_dependencies: [*uv_version]
         priority: 510
         stages: [pre-commit]
+        groups: [fast]
 
       - id: pyproject-fmt-fix
         name: pyproject-fmt
@@ -415,6 +463,7 @@ repos:
         additional_dependencies: [*uv_version]
         priority: 200
         stages: [pre-commit]
+        groups: [fast]
 
       - id: linkcheck
         name: linkcheck
@@ -423,6 +472,7 @@ repos:
         language: python
         types_or: [rst]
         stages: [manual]
+        groups: [docs]
         priority: 610
         pass_filenames: false
         additional_dependencies: [*uv_version]
@@ -434,6 +484,7 @@ repos:
         language: python
         types_or: [rst]
         stages: [manual]
+        groups: [docs]
         priority: 610
         pass_filenames: false
         additional_dependencies: [*uv_version]
@@ -444,6 +495,7 @@ repos:
           docs/build/.doctrees-html
         language: python
         stages: [manual]
+        groups: [docs]
         priority: 610
         pass_filenames: false
         additional_dependencies: [*uv_version]
@@ -457,6 +509,7 @@ repos:
         additional_dependencies: [*uv_version]
         priority: 210
         stages: [pre-commit]
+        groups: [fast]
 
       - id: zizmor
         name: zizmor
@@ -467,6 +520,7 @@ repos:
         additional_dependencies: [*uv_version]
         priority: 500
         stages: [pre-commit]
+        groups: [fast]
 
       - id: sphinx-lint
         name: sphinx-lint
@@ -476,3 +530,4 @@ repos:
         additional_dependencies: [*uv_version]
         priority: 500
         stages: [pre-commit]
+        groups: [fast]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -198,7 +198,7 @@ repos:
       - id: mypy
         name: mypy
         stages: [pre-push]
-        groups: [typecheck]
+        groups: [mypy]
         priority: 520
         entry: uv run --extra=dev -m mypy --num-workers=4
         language: python
@@ -210,7 +210,7 @@ repos:
       - id: mypy-docs
         name: mypy-docs
         stages: [pre-push]
-        groups: [typecheck]
+        groups: [mypy]
         priority: 540
         entry: uv run --extra=dev doccmd --no-write-to-file --language=python --command="mypy
           --num-workers=4"
@@ -221,7 +221,7 @@ repos:
       - id: check-manifest
         name: check-manifest
         stages: [pre-push]
-        groups: [typecheck]
+        groups: [fast]
         priority: 520
         entry: uv run --extra=dev -m check_manifest
         language: python
@@ -231,7 +231,7 @@ repos:
       - id: pyright
         name: pyright
         stages: [pre-push]
-        groups: [typecheck]
+        groups: [pyright]
         priority: 520
         entry: uv run --extra=dev -m pyright .
         language: python
@@ -242,7 +242,7 @@ repos:
       - id: pyright-docs
         name: pyright-docs
         stages: [pre-push]
-        groups: [typecheck]
+        groups: [pyright]
         priority: 540
         entry: uv run --extra=dev doccmd --no-write-to-file --example-workers 0 --language=python
           --command="pyright"
@@ -253,7 +253,7 @@ repos:
       - id: pyright-verifytypes
         name: pyright-verifytypes
         stages: [pre-push]
-        groups: [typecheck]
+        groups: [pyright]
         priority: 530
         entry: uv run --extra=dev -m pyright --ignoreexternal --verifytypes literalizer
         language: python
@@ -264,7 +264,7 @@ repos:
       - id: ty
         name: ty
         stages: [pre-push]
-        groups: [typecheck]
+        groups: [ty]
         priority: 520
         entry: uv run --extra=dev ty check
         language: python
@@ -275,7 +275,7 @@ repos:
       - id: ty-docs
         name: ty-docs
         stages: [pre-push]
-        groups: [typecheck]
+        groups: [ty]
         priority: 540
         entry: uv run --extra=dev doccmd --no-write-to-file --example-workers 0 --language=python
           --command="ty check"
@@ -286,7 +286,7 @@ repos:
       - id: pyrefly
         name: pyrefly
         stages: [pre-push]
-        groups: [typecheck]
+        groups: [pyrefly]
         priority: 520
         entry: uv run --extra=dev pyrefly check
         language: python
@@ -297,7 +297,7 @@ repos:
       - id: pyrefly-docs
         name: pyrefly-docs
         stages: [pre-push]
-        groups: [typecheck]
+        groups: [pyrefly]
         priority: 540
         entry: uv run --extra=dev doccmd --no-write-to-file --example-workers 0 --language=python
           --command="pyrefly check"
@@ -353,7 +353,7 @@ repos:
         entry: uv run --extra=dev -m pylint *.py src/ tests/ docs/
         language: python
         stages: [manual]
-        groups: [docs]
+        groups: [pylint]
         priority: 600
         pass_filenames: false
         additional_dependencies: [*uv_version]
@@ -364,7 +364,7 @@ repos:
           --command="pylint"
         language: python
         stages: [manual]
-        groups: [docs]
+        groups: [pylint]
         priority: 605
         types_or: [markdown, rst]
         additional_dependencies: [*uv_version]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -198,7 +198,7 @@ repos:
       - id: mypy
         name: mypy
         stages: [pre-push]
-        groups: [mypy]
+        groups: [typecheck]
         priority: 520
         entry: uv run --extra=dev -m mypy --num-workers=4
         language: python
@@ -210,7 +210,7 @@ repos:
       - id: mypy-docs
         name: mypy-docs
         stages: [pre-push]
-        groups: [mypy]
+        groups: [typecheck]
         priority: 540
         entry: uv run --extra=dev doccmd --no-write-to-file --language=python --command="mypy
           --num-workers=4"
@@ -231,7 +231,7 @@ repos:
       - id: pyright
         name: pyright
         stages: [pre-push]
-        groups: [pyright]
+        groups: [typecheck]
         priority: 520
         entry: uv run --extra=dev -m pyright .
         language: python
@@ -242,7 +242,7 @@ repos:
       - id: pyright-docs
         name: pyright-docs
         stages: [pre-push]
-        groups: [pyright]
+        groups: [typecheck]
         priority: 540
         entry: uv run --extra=dev doccmd --no-write-to-file --example-workers 0 --language=python
           --command="pyright"
@@ -253,7 +253,7 @@ repos:
       - id: pyright-verifytypes
         name: pyright-verifytypes
         stages: [pre-push]
-        groups: [pyright]
+        groups: [typecheck]
         priority: 530
         entry: uv run --extra=dev -m pyright --ignoreexternal --verifytypes literalizer
         language: python
@@ -264,7 +264,7 @@ repos:
       - id: ty
         name: ty
         stages: [pre-push]
-        groups: [ty]
+        groups: [typecheck]
         priority: 520
         entry: uv run --extra=dev ty check
         language: python
@@ -275,7 +275,7 @@ repos:
       - id: ty-docs
         name: ty-docs
         stages: [pre-push]
-        groups: [ty]
+        groups: [typecheck]
         priority: 540
         entry: uv run --extra=dev doccmd --no-write-to-file --example-workers 0 --language=python
           --command="ty check"
@@ -286,7 +286,7 @@ repos:
       - id: pyrefly
         name: pyrefly
         stages: [pre-push]
-        groups: [pyrefly]
+        groups: [typecheck]
         priority: 520
         entry: uv run --extra=dev pyrefly check
         language: python
@@ -297,7 +297,7 @@ repos:
       - id: pyrefly-docs
         name: pyrefly-docs
         stages: [pre-push]
-        groups: [pyrefly]
+        groups: [typecheck]
         priority: 540
         entry: uv run --extra=dev doccmd --no-write-to-file --example-workers 0 --language=python
           --command="pyrefly check"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ optional-dependencies.dev = [
     "interrogate==1.7.0",
     "mypy[faster-cache]==2.1.0",
     "mypy-strict-kwargs==2026.5.20.1",
-    "prek==0.4.3",
+    "prek==0.4.4",
     "pydocstringformatter==0.7.5",
     "pygments==2.20.0",
     "pylint[spelling]==4.0.5",


### PR DESCRIPTION
Selects lint hooks by prek group (`groups:` in `.pre-commit-config.yaml`) instead of by hook stage, which needs the `--group` flag added in prek 0.4.4 (bumped from 0.4.3). Hooks are grouped `fast` / `typecheck` / `pylint` / `docs` and the lint matrix shards on that axis; the existing `stages:` keys are kept so local git hooks are unchanged. Lint is run Linux-only because every hook is platform-agnostic and the package's Windows runtime is already covered by the pytest matrix in `ci.yml`; an experiment re-adding Windows and sharding per-tool was measured in CI to be slower (the fast-hooks-on-Windows job is the floor, and the larger matrix queued on the runner pool), so it was dropped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes only CI matrix and pre-commit hook grouping; no application runtime or security logic.
> 
> **Overview**
> **CI lint** is resharded from hook **stages** (`pre-commit` / `pre-push` / `manual`) to **prek groups** so slow checks run on separate runners in parallel.
> 
> Every hook in `.pre-commit-config.yaml` gets a `groups:` tag: **`fast`** (formatters, quick checks, plus `check-manifest`), **`typecheck`** (mypy / pyright / ty / pyrefly and doc variants), **`pylint`**, and **`docs`** (Sphinx html, spelling, linkcheck). The **`pre-commit`** job matrix becomes `group: [fast, typecheck, pylint, docs]` × Python 3.12–3.14 and runs `prek run --all-files --group ${{ matrix.group }}` on **`ubuntu-latest` only**—Windows and the old stage/platform matrix (including Windows excludes for heavy stages) are removed. **`prek`** is bumped **0.4.3 → 0.4.4** in dev deps for `--group`; existing `stages:` on hooks are unchanged for local git hooks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 578deb6e1bedf26e97c2e49968bbc529b9a4f1cb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->